### PR TITLE
fix: Copilot review #51 – icon sizes, GNU grep regex, vollständige signing-Extensions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -259,22 +259,24 @@ jobs:
 
       - name: Check no keystore files are committed
         run: |
-          FOUND=$(git ls-files | grep -E "\.(keystore|jks)$" || true)
+          FOUND=$(git ls-files | grep -E "\.(keystore|jks|p12|p8)$" || true)
           if [ -n "$FOUND" ]; then
-            echo "❌ Keystore committed: $FOUND"; exit 1
+            echo "❌ Signing file committed: $FOUND"; exit 1
           fi
-          echo "✅ No keystore files found"
+          echo "✅ No signing files found"
 
-      - name: Check .gitignore covers keystore patterns
+      - name: Check .gitignore covers signing file patterns
         run: |
-          if ! grep -q "\.jks" .gitignore; then
-            echo "❌ .gitignore missing *.jks"; exit 1
-          fi
-          echo "✅ Keystore patterns are gitignored"
+          for pat in "\.jks" "\.keystore" "\.p12" "\.p8"; do
+            if ! grep -q "$pat" .gitignore; then
+              echo "❌ .gitignore missing $pat"; exit 1
+            fi
+          done
+          echo "✅ Signing file patterns are gitignored"
 
       - name: Scan for hardcoded keystore passwords
         run: |
-          if grep -rEi "(keystorePassword|keyPassword|storePassword)\s*=\s*\S" . \
+          if grep -rEi "(keystorePassword|keyPassword|storePassword)[[:space:]]*=[[:space:]]*[^[:space:]]" . \
               --exclude-dir=node_modules --exclude-dir=.git --exclude="*.md" 2>/dev/null; then
             echo "❌ Hardcoded keystore password found! Use CI secrets instead."; exit 1
           fi

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -64,7 +64,7 @@ fi
 
 # Scan staged diff for hardcoded credentials (#44)
 echo "Checking for hardcoded credentials..."
-if git diff --cached | grep "^+" | grep -v "^+++" | grep -qEi "(keystorePassword|keyPassword|storePassword)\s*=\s*\S"; then
+if git diff --cached | grep "^+" | grep -v "^+++" | grep -qEi "(keystorePassword|keyPassword|storePassword)[[:space:]]*=[[:space:]]*[^[:space:]]"; then
   echo "❌ ERROR: Hardcoded keystore password detected in staged changes!"
   echo "Use environment variables or CI secrets instead."
   exit 1

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -12,17 +12,12 @@
   "icons": [
     {
       "src": "/Pflanzkalender/assets/icon.png",
-      "sizes": "192x192",
-      "type": "image/png"
-    },
-    {
-      "src": "/Pflanzkalender/assets/icon.png",
-      "sizes": "512x512",
+      "sizes": "1024x1024",
       "type": "image/png"
     },
     {
       "src": "/Pflanzkalender/assets/adaptive-icon.png",
-      "sizes": "512x512",
+      "sizes": "1024x1024",
       "type": "image/png",
       "purpose": "maskable"
     }


### PR DESCRIPTION
Follow-up zu PR #51. Behebt alle 4 Copilot-Review-Kommentare.

## Fixes

**Comment 1 – manifest.json icon sizes**
`icon.png` und `adaptive-icon.png` sind beide 1024×1024 px. Die deklarierten `sizes: "192x192"` / `"512x512"` stimmten nicht mit der tatsächlichen Bildgröße überein. Korrigiert auf `"1024x1024"`.

**Comment 2 – Pre-Commit Regex (GNU grep ERE)**
`\s` / `\S` funktionieren in GNU grep mit `-E` nicht. Ergibt false negatives für `storePassword = "..."`.
Fix: `[[:space:]]*` / `[^[:space:]]`.

**Comment 3 – CI `keystore-secrets` Regex (GNU grep ERE)**
Gleicher Bug wie Comment 2, dieselbe Korrektur.

**Comment 4 – CI scannt nur `.keystore|.jks`, nicht `.p12`/`.p8`**
Inkonsistenz mit `.gitignore` (enthält bereits alle vier) und Pre-Commit Hook.
CI-Job erweitert auf alle vier Extensions, `.gitignore`-Check prüft jetzt alle vier Patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)