### PR TITLE
docs: Keystore-Pfad in .gitignore und pre-commit dokumentieren

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ coverage/
 # Private documentation (local only, never commit)
 docs/private/
 
-# Keystore & signing files
+# Keystore & signing files – lokal ablegen unter:
+# ~/Documents/Programmierung/Projects/Keystore/Keystore_Pflanzkalender/
 *.keystore

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -59,6 +59,7 @@ STAGED_KEYSTORE=$(git diff --cached --name-only | grep -E "\.(keystore|jks|p12|p
 if [ -n "$STAGED_KEYSTORE" ]; then
   echo "❌ ERROR: Keystore/signing file staged for commit!"
   echo "File: $STAGED_KEYSTORE"
+  echo "Keystore lokal ablegen: ~/Documents/Programmierung/Projects/Keystore/Keystore_Pflanzkalender/"
   exit 1
 fi
 


### PR DESCRIPTION
Keystore für Pflanzkalender gehört lokal nach:
`~/Documents/Programmierung/Projects/Keystore/Keystore_Pflanzkalender/`

Analog zur bestehenden Struktur der anderen Projekte:
- `Keystore_1x1_trainer/`
- `Keystore_Eisenhauer/`
- `keystore_EnergyPrice/`
- `DrawFromMemory/`

## Änderungen
- `.gitignore`: Kommentar mit dem korrekten lokalen Pfad ergänzt
- `.husky/pre-commit`: Fehlermeldung zeigt jetzt den richtigen Ablageort wenn ein Signing-File versehentlich gestaged wird

🤖 Generated with [Claude Code](https://claude.com/claude-code)