### PR TITLE
fix: Copilot review #52 – Credential-Regex auf Literale einschränken, Step-Name korrigieren

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -257,7 +257,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Check no keystore files are committed
+      - name: Check no signing files are committed
         run: |
           FOUND=$(git ls-files | grep -E "\.(keystore|jks|p12|p8)$" || true)
           if [ -n "$FOUND" ]; then
@@ -276,9 +276,9 @@ jobs:
 
       - name: Scan for hardcoded keystore passwords
         run: |
-          if grep -rEi "(keystorePassword|keyPassword|storePassword)[[:space:]]*=[[:space:]]*[^[:space:]]" . \
+          if grep -rEi "(keystorePassword|keyPassword|storePassword)[[:space:]]*=[[:space:]]*[\"'][^\"']" . \
               --exclude-dir=node_modules --exclude-dir=.git --exclude="*.md" 2>/dev/null; then
-            echo "❌ Hardcoded keystore password found! Use CI secrets instead."; exit 1
+            echo "❌ Hardcoded keystore password (string literal) found! Use CI secrets instead."; exit 1
           fi
           echo "✅ No hardcoded keystore passwords"
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -65,8 +65,8 @@ fi
 
 # Scan staged diff for hardcoded credentials (#44)
 echo "Checking for hardcoded credentials..."
-if git diff --cached | grep "^+" | grep -v "^+++" | grep -qEi "(keystorePassword|keyPassword|storePassword)[[:space:]]*=[[:space:]]*[^[:space:]]"; then
-  echo "❌ ERROR: Hardcoded keystore password detected in staged changes!"
+if git diff --cached | grep "^+" | grep -v "^+++" | grep -qEi "(keystorePassword|keyPassword|storePassword)[[:space:]]*=[[:space:]]*[\"'][^\"']"; then
+  echo "❌ ERROR: Hardcoded keystore password (string literal) detected in staged changes!"
   echo "Use environment variables or CI secrets instead."
   exit 1
 fi


### PR DESCRIPTION
Follow-up zu PR #52. Behebt alle 3 Copilot-Review-Kommentare.

## Fixes

**Comments 1 & 2 – Credential-Regex zu breit (Pre-Commit + CI)**
Die bisherige Regex traf auch sichere Patterns wie `keystorePassword = System.getenv(...)`.
Die Fehlermeldung sprach aber von „Hardcoded". Fix: Pattern auf String-Literale eingeschränkt
(`[\"'][^\"']` statt `[^[:space:]]`) – trifft nur `= "..."` / `= '...'`.

**Comment 3 – Step-Name inkonsistent (CI)**
Step hieß noch „Check no keystore files", Meldungen sagten aber „signing file".
Umbenannt auf „Check no signing files".

🤖 Generated with [Claude Code](https://claude.com/claude-code)