### PR TITLE
refactor: Issue #56 Phase 3 – Duplikat & Type Safety Fixes

### DIFF
--- a/__tests__/components/ActivityBar.test.tsx
+++ b/__tests__/components/ActivityBar.test.tsx
@@ -27,7 +27,7 @@ describe('ActivityBar Component', () => {
   };
 
   it('renders without crashing', () => {
-    const { root } = render(<ActivityBar activity={mockActivity} index={0} totalActivities={1} />);
+    const { root } = render(<ActivityBar activity={mockActivity} />);
 
     expect(root).toBeTruthy();
   });
@@ -37,9 +37,7 @@ describe('ActivityBar Component', () => {
   });
 
   it('renders activity bar with label', () => {
-    const { getByText } = render(
-      <ActivityBar activity={mockActivity} index={0} totalActivities={1} />
-    );
+    const { getByText } = render(<ActivityBar activity={mockActivity} />);
 
     expect(getByText('Aussaat')).toBeTruthy();
   });
@@ -55,8 +53,6 @@ describe('ActivityBar Component', () => {
           color: '#FF6B6B',
           label: 'Ernte',
         }}
-        index={0}
-        totalActivities={1}
       />
     );
 

--- a/__tests__/contexts/PlantContext.test.tsx
+++ b/__tests__/contexts/PlantContext.test.tsx
@@ -100,6 +100,7 @@ describe('PlantContext – addPlant', () => {
         activities: [],
         isDefault: false,
         userId: null,
+        notes: '',
       });
     });
 
@@ -118,6 +119,7 @@ describe('PlantContext – addPlant', () => {
         activities: [],
         isDefault: false,
         userId: null,
+        notes: '',
       });
     });
 
@@ -134,6 +136,7 @@ describe('PlantContext – addPlant', () => {
         activities: [],
         isDefault: false,
         userId: null,
+        notes: '',
       });
     });
 
@@ -157,7 +160,13 @@ describe('PlantContext – updatePlant', () => {
 
     let plantId: string;
     await act(async () => {
-      result.current.addPlant({ name: 'Original', activities: [], isDefault: false, userId: null });
+      result.current.addPlant({
+        name: 'Original',
+        activities: [],
+        isDefault: false,
+        userId: null,
+        notes: '',
+      });
     });
     plantId = result.current.plants.find((p) => p.name === 'Original')!.id;
 
@@ -182,7 +191,13 @@ describe('PlantContext – deletePlant', () => {
     await waitForLoaded(result);
 
     await act(async () => {
-      result.current.addPlant({ name: 'ToDelete', activities: [], isDefault: false, userId: null });
+      result.current.addPlant({
+        name: 'ToDelete',
+        activities: [],
+        isDefault: false,
+        userId: null,
+        notes: '',
+      });
     });
 
     const plant = result.current.plants.find((p) => p.name === 'ToDelete')!;
@@ -214,6 +229,7 @@ describe('PlantContext – addActivity', () => {
         activities: [],
         isDefault: false,
         userId: null,
+        notes: '',
       });
     });
 
@@ -252,6 +268,7 @@ describe('PlantContext – updateActivity', () => {
         activities: [],
         isDefault: false,
         userId: null,
+        notes: '',
       });
     });
 
@@ -296,6 +313,7 @@ describe('PlantContext – deleteActivity', () => {
         activities: [],
         isDefault: false,
         userId: null,
+        notes: '',
       });
     });
 
@@ -341,6 +359,7 @@ describe('PlantContext – resetToDefaults', () => {
         activities: [],
         isDefault: false,
         userId: null,
+        notes: '',
       });
     });
 

--- a/src/components/ActivityBar.tsx
+++ b/src/components/ActivityBar.tsx
@@ -1,7 +1,24 @@
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Platform } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Platform,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 import { Activity } from '../types';
 import { getContrastTextColor } from '../utils/colorUtils';
+import { MONTH_SHORT } from '../utils/monthHelper';
+
+interface TouchableWebProps {
+  style: StyleProp<ViewStyle>;
+  onPress?: () => void;
+  activeOpacity: number;
+  onMouseEnter?: () => void;
+  onMouseLeave?: () => void;
+}
 
 interface ActivityBarProps {
   activity: Activity;
@@ -20,29 +37,15 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
   const startPosition = (activity.startMonth / totalMonths) * 100;
   const width = ((activity.endMonth - activity.startMonth + 1) / totalMonths) * 100;
 
-  const monthNames = [
-    'Jan',
-    'Feb',
-    'Mär',
-    'Apr',
-    'Mai',
-    'Jun',
-    'Jul',
-    'Aug',
-    'Sep',
-    'Okt',
-    'Nov',
-    'Dez',
-  ];
   const getMonthLabel = (halfMonth: number) => {
     const monthIndex = Math.floor(halfMonth / 2);
     const half = halfMonth % 2 === 0 ? '1. H' : '2. H';
-    return `${monthNames[monthIndex]} ${half}`;
+    return `${MONTH_SHORT[monthIndex]} ${half}`;
   };
 
   const tooltipText = `${activity.label}\n${getMonthLabel(activity.startMonth)} - ${getMonthLabel(activity.endMonth)}`;
 
-  const touchableProps: any = {
+  const touchableProps: TouchableWebProps = {
     style: [
       styles.activityBar,
       {

--- a/src/screens/AgendaScreen.tsx
+++ b/src/screens/AgendaScreen.tsx
@@ -149,9 +149,9 @@ export const AgendaScreen: React.FC = () => {
 
       <ScrollView horizontal style={styles.scrollView}>
         <View style={styles.columnsContainer}>
-          {renderColumn(t('agenda.previous'), previousActivities, previousMonth)}
-          {renderColumn(t('agenda.current'), currentActivities, currentMonth)}
-          {renderColumn(t('agenda.next'), nextActivities, nextMonth)}
+          {renderColumn(String(t('agenda.previous')), previousActivities, previousMonth)}
+          {renderColumn(String(t('agenda.current')), currentActivities, currentMonth)}
+          {renderColumn(String(t('agenda.next')), nextActivities, nextMonth)}
         </View>
       </ScrollView>
     </View>


### PR DESCRIPTION
## Summary

Closes #56 (Phase 3)

- **ActivityBar**: lokales `monthNames`-Array durch `MONTH_SHORT` aus `monthHelper.ts` ersetzt (Duplikat beseitigt)
- **ActivityBar**: `touchableProps: any` durch explizites `TouchableWebProps`-Interface ersetzt
- **AgendaScreen**: `t()`-Rückgabe via `String()` gecastet (`TranslationValue`-TS-Fehler behoben)
- **Tests**: fehlendes `notes`-Feld in `addPlant`-Aufrufen ergänzt, nicht existierende Props in `ActivityBar`-Tests entfernt

## Test plan

- [x] 254/254 Tests grün
- [x] `tsc --noEmit` ohne Fehler
- [x] Prettier sauber