### PR TITLE
fix: activity bars misaligned with month headers on wide screens

### DIFF
--- a/src/components/PlantRow.tsx
+++ b/src/components/PlantRow.tsx
@@ -33,6 +33,7 @@ export const PlantRow: React.FC<PlantRowProps> = ({
   const [notesText, setNotesText] = useState(plant.notes);
 
   const months = Array.from({ length: totalMonths }, (_, i) => i);
+  const gridWidth = totalMonths * cellWidth;
 
   const activitiesWithRows = useMemo(
     () => calculateActivityRows(plant.activities),
@@ -59,7 +60,7 @@ export const PlantRow: React.FC<PlantRowProps> = ({
 
   return (
     <View style={[styles.row, { minHeight }]}>
-      <View style={styles.monthsContainer}>
+      <View style={[styles.monthsContainer, { width: gridWidth }]}>
         {months.map((monthIndex) => {
           const absoluteMonthIndex = monthIndex + monthOffset;
           const isCurrentHalfMonth =
@@ -125,7 +126,6 @@ const styles = StyleSheet.create({
   },
   monthsContainer: {
     flexDirection: 'row',
-    flex: 1,
     position: 'relative',
   },
   monthCell: {


### PR DESCRIPTION
## Summary

- `monthsContainer` in `PlantRow` hatte `flex: 1`, was dazu führte, dass der Container auf breiten/Laptop-Bildschirmen breiter als `totalMonths * cellWidth` wurde
- `ActivityBar` berechnet die Position als `%` der Container-Breite — war der Container breiter als das Gitter, verschoben sich die Balken nach rechts, weg von den zugehörigen Header-Spalten
- Fix: `flex: 1` entfernt, stattdessen explizite `width = totalMonths * cellWidth` gesetzt

## Test plan

- [ ] Kalender auf Laptop/breitem Bildschirm öffnen: Balken (Aussäen, Ernten, …) müssen exakt unter den Monats-Spalten im Header liegen
- [ ] Portrait-Modus (schmal / mobil) prüfen: Layout unverändert korrekt
- [ ] 254 bestehende Tests grün (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)