### PR TITLE
feat: add 'Add to garden' button in ClimateScreen (#90)

### DIFF
--- a/__tests__/screens/ClimateScreen.test.tsx
+++ b/__tests__/screens/ClimateScreen.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import { ClimateScreen } from '../../src/screens/ClimateScreen';
+
+const mockAddPlant = jest.fn();
+const mockPlants: { id: string; name: string }[] = [];
+
+jest.mock('../../src/hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: {
+      background: '#fff',
+      text: '#000',
+      textSecondary: '#666',
+      border: '#ddd',
+      surface: '#f5f5f5',
+      primary: '#4CAF50',
+    },
+  }),
+}));
+
+jest.mock('../../src/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ language: 'de' }),
+}));
+
+jest.mock('../../src/contexts/PlantContext', () => ({
+  usePlants: () => ({ plants: mockPlants, addPlant: mockAddPlant }),
+}));
+
+describe('ClimateScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockPlants.length = 0;
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('renders without crashing', () => {
+    const { getByText } = render(<ClimateScreen />);
+    expect(getByText('Klimafit gärtnern')).toBeTruthy();
+  });
+
+  it('shows "Zum Garten hinzufügen" button for each visible recommendation', () => {
+    const { getAllByText } = render(<ClimateScreen />);
+    const buttons = getAllByText('Zum Garten hinzufügen');
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it('calls addPlant and shows "Hinzugefügt ✓" state on press', async () => {
+    const { getAllByText, queryAllByText } = render(<ClimateScreen />);
+    const addButtons = getAllByText('Zum Garten hinzufügen');
+    fireEvent.press(addButtons[0]);
+    expect(mockAddPlant).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(queryAllByText('Hinzugefügt ✓').length).toBeGreaterThan(0));
+  });
+
+  it('reverts "Hinzugefügt ✓" back after 2 seconds', async () => {
+    const { getAllByText, queryAllByText } = render(<ClimateScreen />);
+    fireEvent.press(getAllByText('Zum Garten hinzufügen')[0]);
+    await waitFor(() => expect(queryAllByText('Hinzugefügt ✓').length).toBeGreaterThan(0));
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    await waitFor(() => expect(queryAllByText('Hinzugefügt ✓').length).toBe(0));
+  });
+
+  it('disables button and shows "Bereits im Garten" when plant already exists', () => {
+    mockPlants.push({ id: '1', name: 'Süßkartoffel' });
+    const { getByText } = render(<ClimateScreen />);
+    expect(getByText('Bereits im Garten')).toBeTruthy();
+  });
+
+  it('does not call addPlant again on double-tap', async () => {
+    const { getAllByText } = render(<ClimateScreen />);
+    const addButtons = getAllByText('Zum Garten hinzufügen');
+    fireEvent.press(addButtons[0]);
+    fireEvent.press(addButtons[0]);
+    expect(mockAddPlant).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/screens/ClimateScreen.tsx
+++ b/src/screens/ClimateScreen.tsx
@@ -284,10 +284,9 @@ export const ClimateScreen: React.FC = () => {
 
   const isInGarden = useCallback(
     (rec: ClimateRecommendation) => {
-      const name = language === 'de' ? rec.name.de : rec.name.en;
-      return plants.some((p) => p.name === name);
+      return plants.some((p) => p.name === rec.name.de || p.name === rec.name.en);
     },
-    [plants, language]
+    [plants]
   );
 
   const handleAddToGarden = useCallback(
@@ -429,8 +428,8 @@ export const ClimateScreen: React.FC = () => {
                   </View>
 
                   <TouchableOpacity
-                    onPress={() => !inGarden && handleAddToGarden(rec)}
-                    disabled={inGarden}
+                    onPress={() => !inGarden && !justAdded && handleAddToGarden(rec)}
+                    disabled={inGarden || justAdded}
                     style={[
                       styles.addButton,
                       {

--- a/src/screens/ClimateScreen.tsx
+++ b/src/screens/ClimateScreen.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
 import { useTheme } from '../hooks/useTheme';
 import { useLanguage } from '../contexts/LanguageContext';
+import { usePlants } from '../contexts/PlantContext';
 
 type FilterCategory = 'all' | 'vegetable' | 'flower' | 'tree';
 
@@ -277,7 +278,42 @@ function ResistanceDots({
 export const ClimateScreen: React.FC = () => {
   const { theme } = useTheme();
   const { language } = useLanguage();
+  const { plants, addPlant } = usePlants();
   const [activeFilter, setActiveFilter] = useState<FilterCategory>('all');
+  const [addedKeys, setAddedKeys] = useState<Set<string>>(new Set());
+
+  const isInGarden = useCallback(
+    (rec: ClimateRecommendation) => {
+      const name = language === 'de' ? rec.name.de : rec.name.en;
+      return plants.some((p) => p.name === name);
+    },
+    [plants, language]
+  );
+
+  const handleAddToGarden = useCallback(
+    (rec: ClimateRecommendation) => {
+      const name = language === 'de' ? rec.name.de : rec.name.en;
+      addPlant({
+        name,
+        isDefault: false,
+        userId: null,
+        category: rec.category,
+        location: undefined,
+        activities: [],
+        notes: '',
+      });
+      const cardKey = `${rec.category}-${rec.name.de}`;
+      setAddedKeys((prev) => new Set(prev).add(cardKey));
+      setTimeout(() => {
+        setAddedKeys((prev) => {
+          const next = new Set(prev);
+          next.delete(cardKey);
+          return next;
+        });
+      }, 2000);
+    },
+    [language, addPlant]
+  );
 
   const filtered =
     activeFilter === 'all'
@@ -291,6 +327,9 @@ export const ClimateScreen: React.FC = () => {
       : 'Recommended plants for hot, dry summers';
   const droughtLabel = language === 'de' ? 'Trockenresistenz' : 'Drought resistance';
   const heatLabel = language === 'de' ? 'Hitzetoleranz' : 'Heat tolerance';
+  const addLabel = language === 'de' ? 'Zum Garten hinzufügen' : 'Add to garden';
+  const addedLabel = language === 'de' ? 'Hinzugefügt ✓' : 'Added ✓';
+  const alreadyLabel = language === 'de' ? 'Bereits im Garten' : 'Already in garden';
 
   return (
     <View style={[styles.container, { backgroundColor: theme.background }]}>
@@ -332,57 +371,90 @@ export const ClimateScreen: React.FC = () => {
 
           {/* Cards */}
           <View style={styles.cards}>
-            {filtered.map((rec) => (
-              <View
-                key={`${rec.category}-${rec.name.de}`}
-                style={[styles.card, { backgroundColor: theme.surface, borderColor: theme.border }]}
-              >
-                <View style={styles.cardHeader}>
-                  <Text style={styles.cardIcon}>{rec.icon}</Text>
-                  <Text style={[styles.cardName, { color: theme.text }]}>
-                    {language === 'de' ? rec.name.de : rec.name.en}
+            {filtered.map((rec) => {
+              const cardKey = `${rec.category}-${rec.name.de}`;
+              const inGarden = isInGarden(rec);
+              const justAdded = addedKeys.has(cardKey);
+              return (
+                <View
+                  key={cardKey}
+                  style={[
+                    styles.card,
+                    { backgroundColor: theme.surface, borderColor: theme.border },
+                  ]}
+                >
+                  <View style={styles.cardHeader}>
+                    <Text style={styles.cardIcon}>{rec.icon}</Text>
+                    <Text style={[styles.cardName, { color: theme.text }]}>
+                      {language === 'de' ? rec.name.de : rec.name.en}
+                    </Text>
+                  </View>
+
+                  <View style={styles.traits}>
+                    {(language === 'de' ? rec.traits.de : rec.traits.en).map((trait) => (
+                      <View
+                        key={trait}
+                        style={[styles.traitBadge, { backgroundColor: theme.background }]}
+                      >
+                        <Text style={[styles.traitText, { color: theme.primary }]}>{trait}</Text>
+                      </View>
+                    ))}
+                  </View>
+
+                  <Text style={[styles.tip, { color: theme.textSecondary }]}>
+                    {language === 'de' ? rec.tip.de : rec.tip.en}
                   </Text>
-                </View>
 
-                <View style={styles.traits}>
-                  {(language === 'de' ? rec.traits.de : rec.traits.en).map((trait) => (
-                    <View
-                      key={trait}
-                      style={[styles.traitBadge, { backgroundColor: theme.background }]}
-                    >
-                      <Text style={[styles.traitText, { color: theme.primary }]}>{trait}</Text>
+                  <View style={styles.resistanceRow}>
+                    <View style={styles.resistanceItem}>
+                      <Text style={[styles.resistanceLabel, { color: theme.textSecondary }]}>
+                        💧 {droughtLabel}
+                      </Text>
+                      <ResistanceDots
+                        level={rec.droughtResistance}
+                        color="#2196F3"
+                        inactiveColor={theme.border}
+                      />
                     </View>
-                  ))}
-                </View>
-
-                <Text style={[styles.tip, { color: theme.textSecondary }]}>
-                  {language === 'de' ? rec.tip.de : rec.tip.en}
-                </Text>
-
-                <View style={styles.resistanceRow}>
-                  <View style={styles.resistanceItem}>
-                    <Text style={[styles.resistanceLabel, { color: theme.textSecondary }]}>
-                      💧 {droughtLabel}
-                    </Text>
-                    <ResistanceDots
-                      level={rec.droughtResistance}
-                      color="#2196F3"
-                      inactiveColor={theme.border}
-                    />
+                    <View style={styles.resistanceItem}>
+                      <Text style={[styles.resistanceLabel, { color: theme.textSecondary }]}>
+                        🌡️ {heatLabel}
+                      </Text>
+                      <ResistanceDots
+                        level={rec.heatTolerance}
+                        color="#FF5722"
+                        inactiveColor={theme.border}
+                      />
+                    </View>
                   </View>
-                  <View style={styles.resistanceItem}>
-                    <Text style={[styles.resistanceLabel, { color: theme.textSecondary }]}>
-                      🌡️ {heatLabel}
+
+                  <TouchableOpacity
+                    onPress={() => !inGarden && handleAddToGarden(rec)}
+                    disabled={inGarden}
+                    style={[
+                      styles.addButton,
+                      {
+                        backgroundColor: justAdded
+                          ? '#4CAF50'
+                          : inGarden
+                            ? theme.border
+                            : theme.primary,
+                      },
+                    ]}
+                    accessibilityLabel={inGarden ? alreadyLabel : addLabel}
+                  >
+                    <Text
+                      style={[
+                        styles.addButtonText,
+                        { color: inGarden ? theme.textSecondary : '#fff' },
+                      ]}
+                    >
+                      {justAdded ? addedLabel : inGarden ? alreadyLabel : addLabel}
                     </Text>
-                    <ResistanceDots
-                      level={rec.heatTolerance}
-                      color="#FF5722"
-                      inactiveColor={theme.border}
-                    />
-                  </View>
+                  </TouchableOpacity>
                 </View>
-              </View>
-            ))}
+              );
+            })}
           </View>
         </View>
       </ScrollView>
@@ -496,5 +568,15 @@ const styles = StyleSheet.create({
     width: 10,
     height: 10,
     borderRadius: 5,
+  },
+  addButton: {
+    marginTop: 14,
+    paddingVertical: 10,
+    borderRadius: 8,
+    alignItems: 'center',
+  },
+  addButtonText: {
+    fontSize: 14,
+    fontWeight: '600',
   },
 });

--- a/src/screens/ClimateScreen.tsx
+++ b/src/screens/ClimateScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { View, Text, StyleSheet, ScrollView, TouchableOpacity } from 'react-native';
 import { useTheme } from '../hooks/useTheme';
 import { useLanguage } from '../contexts/LanguageContext';
@@ -281,6 +281,14 @@ export const ClimateScreen: React.FC = () => {
   const { plants, addPlant } = usePlants();
   const [activeFilter, setActiveFilter] = useState<FilterCategory>('all');
   const [addedKeys, setAddedKeys] = useState<Set<string>>(new Set());
+  const timerRefs = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  useEffect(() => {
+    const timers = timerRefs.current;
+    return () => {
+      timers.forEach((id) => clearTimeout(id));
+    };
+  }, []);
 
   const isInGarden = useCallback(
     (rec: ClimateRecommendation) => {
@@ -291,6 +299,8 @@ export const ClimateScreen: React.FC = () => {
 
   const handleAddToGarden = useCallback(
     (rec: ClimateRecommendation) => {
+      const cardKey = `${rec.category}-${rec.name.de}`;
+      if (isInGarden(rec) || timerRefs.current.has(cardKey)) return;
       const name = language === 'de' ? rec.name.de : rec.name.en;
       addPlant({
         name,
@@ -301,17 +311,18 @@ export const ClimateScreen: React.FC = () => {
         activities: [],
         notes: '',
       });
-      const cardKey = `${rec.category}-${rec.name.de}`;
       setAddedKeys((prev) => new Set(prev).add(cardKey));
-      setTimeout(() => {
+      const id = setTimeout(() => {
         setAddedKeys((prev) => {
           const next = new Set(prev);
           next.delete(cardKey);
           return next;
         });
+        timerRefs.current.delete(cardKey);
       }, 2000);
+      timerRefs.current.set(cardKey, id);
     },
-    [language, addPlant]
+    [language, addPlant, isInGarden]
   );
 
   const filtered =


### PR DESCRIPTION
## Summary

- Jede Empfehlungskarte im Klima-Tab bekommt einen **"Zum Garten hinzufügen"**-Button
- Pflanze wird direkt über `usePlants().addPlant()` mit Kategorie und leerem Aktivitäten-Array angelegt
- Ist die Pflanze bereits im Garten (Namensabgleich), wird der Button grau/disabled mit Label „Bereits im Garten" / „Already in garden"
- 2-Sekunden-Toast-Feedback: Button wechselt kurz auf grün mit „Hinzugefügt ✓" / „Added ✓"
- Button-Labels vollständig i18n (DE/EN)

## Test plan

- [ ] Klima-Tab öffnen → jede Karte hat einen blauen "Zum Garten hinzufügen"-Button
- [ ] Button drücken → Button wird kurz grün ("Hinzugefügt ✓"), danach grau ("Bereits im Garten")
- [ ] Im PlantManagementScreen erscheint die Pflanze mit korrekter Kategorie
- [ ] Im CalendarScreen ist die Pflanze sichtbar
- [ ] Bereits vorhandene Pflanzen (z. B. Standardpflanzen) haben sofort den deaktivierten Button
- [ ] Sprache auf EN wechseln → Button-Labels auf Englisch
- [ ] Alle 254 Tests grün

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)