### PR TITLE
fix: SettingsScreen uses LanguageContext correctly (Issue #84)

### DIFF
--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -53,7 +53,6 @@ describe('SettingsScreen', () => {
 
   it('renders the Settings title', () => {
     const { getByText } = renderWithProviders(<SettingsScreen />);
-    // Default language is 'en' in SettingsScreen (internal state)
     expect(getByText(/Settings|Einstellungen/)).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary

- **Issue #84** reported that `SettingsScreen` used local `useState` for language instead of `LanguageContext`, so toggling the language only affected the Settings screen itself.
- Investigation shows this was already fixed as part of the multilang PR #95 — `SettingsScreen` correctly uses `useLanguage()`, calls `setLanguage()` from context, and AsyncStorage persistence is handled by the context.
- This PR removes the stale test comment `// Default language is 'en' in SettingsScreen (internal state)` that falsely described the pre-fix behavior and was confusing.

## Acceptance Criteria (Issue #84)

- [x] Language switch in Settings immediately updates all screens (via LanguageContext)
- [x] Selected language persists across app restarts (AsyncStorage in LanguageContext:671)
- [x] No duplicate translation state in SettingsScreen

## Test plan

- [ ] All 17 SettingsScreen tests pass (`npm test -- --testPathPattern=SettingsScreen`)
- [ ] Switch language in Settings → verify other screens update immediately
- [ ] Restart app → verify selected language is remembered

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)