### PR TITLE
feat: Splash Screen für PWA und Android TWA (Issue #99)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Add PWA meta tags and .well-known
         run: node scripts/add-pwa-meta-tags.js
 
+      - name: Add PWA splash screen
+        run: node scripts/add-splash-screen.js
+
       - name: Create SPA 404 fallback for client-side routing
         run: cp dist/index.html dist/404.html
 

--- a/.github/workflows/deploy-testing.yml
+++ b/.github/workflows/deploy-testing.yml
@@ -81,6 +81,11 @@ jobs:
         env:
           TESTING: true
 
+      - name: Add PWA splash screen
+        run: node scripts/add-splash-screen.js
+        env:
+          TESTING: true
+
       - name: Create .nojekyll file
         run: touch dist/.nojekyll
 

--- a/app.json
+++ b/app.json
@@ -11,7 +11,7 @@
     "splash": {
       "image": "./assets/splash-icon.png",
       "resizeMode": "contain",
-      "backgroundColor": "#ffffff"
+      "backgroundColor": "#1a7a4a"
     },
     "ios": {
       "supportsTablet": true
@@ -19,7 +19,7 @@
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#ffffff"
+        "backgroundColor": "#1a7a4a"
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "build": "expo export --platform web && node scripts/add-pwa-meta-tags.js",
+    "build": "expo export --platform web && node scripts/add-pwa-meta-tags.js && node scripts/add-splash-screen.js",
     "deploy": "bash scripts/deploy.sh",
     "validate": "./scripts/validate-release.sh",
     "prepare": "husky install",

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -6,7 +6,7 @@
   "scope": "/Pflanzkalender/",
   "display": "standalone",
   "orientation": "portrait",
-  "background_color": "#ffffff",
+  "background_color": "#1a7a4a",
   "theme_color": "#4CAF50",
   "icons": [
     {

--- a/scripts/add-splash-screen.js
+++ b/scripts/add-splash-screen.js
@@ -55,20 +55,28 @@ const splashHtml = `
         splash.classList.add('fade-out');
         setTimeout(function () { splash.style.display = 'none'; }, 350);
       }
-      // Hide once React has mounted content into the root
-      var root = document.getElementById('root') || document.body;
-      var observer = new MutationObserver(function () {
-        if (root.children.length > 1 || (root.id === 'root' && root.children.length > 0)) {
-          observer.disconnect();
-          hideSplash();
-        }
-      });
-      observer.observe(root, { childList: true });
+      // Hide once React has mounted content into the root.
+      // Only observe #root — using document.body as fallback would fire
+      // immediately because the body already contains the splash div.
+      var root = document.getElementById('root');
+      if (root) {
+        var observer = new MutationObserver(function () {
+          if (root.children.length > 0) {
+            observer.disconnect();
+            hideSplash();
+          }
+        });
+        observer.observe(root, { childList: true });
+      }
       // Fallback: hide after 4 s regardless
       setTimeout(hideSplash, 4000);
     })();
   </script>`;
 
-html = html.replace('<body>', '<body>' + splashHtml);
-fs.writeFileSync(indexPath, html, 'utf8');
+const updatedHtml = html.replace('<body>', '<body>' + splashHtml);
+if (updatedHtml === html) {
+  console.error('✗ Could not inject splash screen: <body> tag not found in index.html');
+  process.exit(1);
+}
+fs.writeFileSync(indexPath, updatedHtml, 'utf8');
 console.log('✓ PWA splash screen injected into index.html');

--- a/scripts/add-splash-screen.js
+++ b/scripts/add-splash-screen.js
@@ -1,0 +1,74 @@
+const fs = require('fs');
+const path = require('path');
+
+const distPath = path.join(__dirname, '..', 'dist');
+const indexPath = path.join(distPath, 'index.html');
+
+const isTesting = process.env.TESTING === 'true';
+const baseUrl = isTesting ? '/Pflanzkalender-testing' : '/Pflanzkalender';
+
+if (!fs.existsSync(indexPath)) {
+  console.error('✗ dist/index.html not found');
+  process.exit(1);
+}
+
+let html = fs.readFileSync(indexPath, 'utf8');
+
+if (html.includes('id="pwa-splash"')) {
+  console.log('✓ Splash screen already present in index.html, skipping');
+  process.exit(0);
+}
+
+const splashHtml = `
+  <style>
+    #pwa-splash {
+      position: fixed;
+      top: 0; left: 0; right: 0; bottom: 0;
+      background: #1a7a4a;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 9999;
+      transition: opacity 0.35s ease;
+    }
+    #pwa-splash.fade-out {
+      opacity: 0;
+      pointer-events: none;
+    }
+    #pwa-splash img {
+      width: 128px;
+      height: 128px;
+      border-radius: 28px;
+    }
+  </style>
+  <div id="pwa-splash">
+    <img src="${baseUrl}/icon-512.png" alt="Pflanzkalender" />
+  </div>
+  <script>
+    (function () {
+      var splash = document.getElementById('pwa-splash');
+      if (!splash) return;
+      var hidden = false;
+      function hideSplash() {
+        if (hidden) return;
+        hidden = true;
+        splash.classList.add('fade-out');
+        setTimeout(function () { splash.style.display = 'none'; }, 350);
+      }
+      // Hide once React has mounted content into the root
+      var root = document.getElementById('root') || document.body;
+      var observer = new MutationObserver(function () {
+        if (root.children.length > 1 || (root.id === 'root' && root.children.length > 0)) {
+          observer.disconnect();
+          hideSplash();
+        }
+      });
+      observer.observe(root, { childList: true });
+      // Fallback: hide after 4 s regardless
+      setTimeout(hideSplash, 4000);
+    })();
+  </script>`;
+
+html = html.replace('<body>', '<body>' + splashHtml);
+fs.writeFileSync(indexPath, html, 'utf8');
+console.log('✓ PWA splash screen injected into index.html');

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -28,6 +28,10 @@ node scripts/force-cache-clear.js
 echo "Adding PWA meta tags and .well-known..."
 node scripts/add-pwa-meta-tags.js
 
+# Add PWA splash screen
+echo "Adding PWA splash screen..."
+node scripts/add-splash-screen.js
+
 # Add failsafe debug banner
 echo "Adding failsafe debug banner..."
 node scripts/add-failsafe-banner.js

--- a/twa-manifest.template.json
+++ b/twa-manifest.template.json
@@ -1,0 +1,30 @@
+{
+  "packageId": "com.s540d.pflanzkalender",
+  "host": "s540d.github.io",
+  "name": "Pflanzkalender",
+  "launcherName": "Pflanzkalender",
+  "display": "standalone",
+  "orientation": "portrait",
+  "themeColor": "#4CAF50",
+  "navigationColor": "#1a7a4a",
+  "navigationColorDark": "#1a7a4a",
+  "navigationDividerColor": "#4CAF50",
+  "navigationDividerColorDark": "#4CAF50",
+  "backgroundColor": "#1a7a4a",
+  "splashScreenFadeOutDuration": 300,
+  "splashScreenImage": "assets/icon-512.png",
+  "iconUrl": "https://s540d.github.io/Pflanzkalender/icon-512-maskable.png",
+  "maskableIconUrl": "https://s540d.github.io/Pflanzkalender/icon-512-maskable.png",
+  "startUrl": "/Pflanzkalender/",
+  "webManifestUrl": "https://s540d.github.io/Pflanzkalender/manifest.json",
+  "signingKey": {
+    "path": "./android.keystore",
+    "alias": "android"
+  },
+  "appVersionCode": 1,
+  "appVersionName": "1.3.0",
+  "shortcuts": [],
+  "generatorApp": "bubblewrap-cli",
+  "generatorVersion": "1.21.1",
+  "features": {}
+}


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Closes #99

- **`app.json`**: `expo.splash.backgroundColor` und `android.adaptiveIcon.backgroundColor` von `#ffffff` auf `#1a7a4a` (grüne Theme-Farbe) gesetzt – kein weißer Blitz beim App-Start mehr
- **`public/manifest.json`**: `background_color` auf `#1a7a4a` aktualisiert (PWA Splash bei Installation)
- **`scripts/add-splash-screen.js`**: Neues Build-Script injiziert einen CSS-basierten Splash-Overlay in `dist/index.html`; der Splash blendet sich per MutationObserver aus, sobald React gemountet hat (Fallback: 4 s)
- **Build-Pipeline**: Splash-Injection in `package.json` build, `deploy.sh`, `deploy-production.yml` und `deploy-testing.yml` eingehängt
- **`twa-manifest.template.json`**: Bubblewrap TWA-Konfigurationsvorlage mit `splashScreenFadeOutDuration: 300`, `backgroundColor: "#1a7a4a"` und `splashScreenImage: "assets/icon-512.png"`

## How the PWA splash works

1. Build-Script fügt nach dem Expo-Export ein `<div id="pwa-splash">` mit grünem Hintergrund und zentriertem 128 × 128 App-Icon in den `<body>` von `index.html` ein.
2. Ein inline `<script>` beobachtet das React-Root-Element via `MutationObserver` und blendet den Splash per CSS-Transition aus, sobald React Kinder gerendert hat.
3. Fallback: nach 4 Sekunden wird der Splash unabhängig ausgeblendet.
4. Das Script ist idempotent – mehrfaches Ausführen injiziert den Splash nur einmal.

## Acceptance criteria

- [x] Kein weißer Blitz beim App-Start (PWA und Android TWA)
- [x] Splash Screen zeigt App-Icon zentriert auf `#1a7a4a` Hintergrundfarbe
- [x] Splash Screen blendet sich nach App-Mount aus
- [x] `app.json` → `expo.splash` korrekt konfiguriert
- [x] Android TWA: `twa-manifest.template.json` Splash-Konfiguration gesetzt

## Test plan

- [ ] `npm run build` ausführen und prüfen ob `dist/index.html` den `pwa-splash`-Block enthält
- [ ] PWA im Browser öffnen: grüner Splash mit Icon erscheint kurz, verschwindet nach App-Mount
- [ ] `app.json` auf `backgroundColor: "#1a7a4a"` prüfen
- [ ] `public/manifest.json` auf `background_color: "#1a7a4a"` prüfen
- [ ] `twa-manifest.template.json` als Basis für Bubblewrap-Setup verwenden

https://claude.ai/code/session_01S6sQ3AdraHLz6PyqLkZ2jT
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6sQ3AdraHLz6PyqLkZ2jT)_