### PR TITLE
chore: bump version 1.3.0 → 1.3.1, update docs [SUPERSEDED by #112]

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,12 +30,12 @@ Deploy: GitHub Pages via `gh-pages` unter `/Pflanzkalender/`
 
 ---
 
-## Aktuelle Version: 1.3.0 (main)
+## Aktuelle Version: 1.3.1 (main)
 
-**Stand 2026-05-19:** Splash Screen (Issue #99, PR #106) gemergt. Bekanntes CI-Problem: `Lint & Format Check` schlägt fehl (Issue #108).
+**Stand 2026-05-19:** User-Feedback-Features (Issue #104, PR #107) gemergt: Kalender-Zoom, Pflanzen-Übersetzungen, Suchleiste, Tab-Overflow-Fix.
 
-- **main branch:** v1.3.0 mit Phase 1 + Phase 2 (vollständig, inkl. Icon-Resizing) + Phase 3 (254 Tests, 86.83 % Coverage) + Phase 4a (ESLint 9, Prettier) + Issue #56 Phase 3 (TypeScript-Cleanup, `TouchableWebProps`, Duplikat-Beseitigung) + Klima-Reiter (Issue #55, PR #80) + Splash Screen (Issue #99, PR #106)
-- **testing branch:** v1.3.0 (identisch mit main)
+- **main branch:** v1.3.1 mit Phase 1 + Phase 2 (vollständig, inkl. Icon-Resizing) + Phase 3 (254 Tests, 86.83 % Coverage) + Phase 4a (ESLint 9, Prettier) + Issue #56 Phase 3 (TypeScript-Cleanup, `TouchableWebProps`, Duplikat-Beseitigung) + Klima-Reiter (Issue #55, PR #80) + Splash Screen (Issue #99, PR #106) + User-Feedback (Issue #104, PR #107)
+- **testing branch:** v1.3.1 (identisch mit main)
 
 Versions-Stellen: `package.json`, `app.json`, `src/screens/SettingsScreen.tsx` – immer alle drei synchron halten, sonst schlägt CI fehl.
 
@@ -61,6 +61,7 @@ src/
     defaultPlants.ts           # 32 vordefinierte Pflanzen mit Aktivitäten, Standort, Kategorie
     activityTypes.ts           # Aktivitätstypen mit Farben
     plantMetadata.ts           # PLANT_LOCATION_METADATA + PLANT_CATEGORY_METADATA (Single Source of Truth)
+    plantNames.ts              # PLANT_NAME_EN + getPlantDisplayName() – DE↔EN Übersetzung für Pflanzennamen
     theme.ts                   # Farbpalette
   services/
     storage.ts                 # AsyncStorage Wrapper
@@ -243,6 +244,7 @@ Vollständige Roadmap: https://github.com/S540d/Pflanzkalender/issues/47
 
 | Was                                         | Wann       | Details                                                                                                                                                |
 | ------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **PR #107:** Issue #104 – User-Feedback     | 2026-05-19 | ✅ main `f8a65f5`: Kalender-Zoom (3 Stufen), Pflanzen-Übersetzungen (`plantNames.ts`), Suchleiste in Pflanzenverwaltung, Tab-Overflow-Fix               |
 | **PR #106:** Issue #99 – Splash Screen      | 2026-05-19 | ✅ main `4b9be2e`: `app.json` splash+adaptive-icon `#1a7a4a`, `manifest.json` background, `scripts/add-splash-screen.js`, `twa-manifest.template.json` |
 | **fix:** PWA Icon-Resizing                  | 2026-05-14 | ✅ main `4e66719`: Icons auf 192×192 / 512×512 resized (waren 1024×1024); generate-icons.js prüft jetzt Pixeldimensionen                               |
 | **PR #80:** Issue #55 – Klima-Reiter        | 2026-05-11 | ✅ main `f7c59af`: `ClimateScreen.tsx` mit 15 Empfehlungen, 4 Filter-Tabs, Trocken-/Hitze-Bewertung, DE/EN, Dark-Mode                                  |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,7 @@ Vollständige Roadmap: https://github.com/S540d/Pflanzkalender/issues/47
 - **#47** Roadmap: Phase 4b (Expo Router) + Phase 5 (Play Store)
 - **#48** Klimazonen-Unterstützung – unterschiedliche Aktivitätszeiträume je Region (Ziel: v2.0.0)
 - **#108** CI `Lint & Format Check` schlägt fehl (lokal 45/50 Warnings + Prettier OK, aber CI failed) – betrifft mehrere PRs; auf main einmalig lösen
+- **PR #110** 🔄 Release-Preparation für v1.3.1: Version-Bump + CLAUDE.md Update (pending CI)
 
 ---
 

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Pflanzkalender",
     "slug": "Pflanzkalender",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pflanzkalender",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/src/contexts/LanguageContext.tsx
+++ b/src/contexts/LanguageContext.tsx
@@ -99,7 +99,7 @@ const translations: Record<Language, Translations> = {
     'settings.support': '☕ Support me',
     'settings.feedback': '📧 Feedback',
     'settings.about': 'Über',
-    'settings.version': 'Version 1.3.0',
+    'settings.version': 'Version 1.3.1',
     'settings.license': 'Lizenz',
     'settings.licenseDetails':
       'Open Source • MIT Lizenz\nKeine kommerzielle Nutzung ohne Genehmigung',
@@ -225,7 +225,7 @@ const translations: Record<Language, Translations> = {
     'settings.support': '☕ Support me',
     'settings.feedback': '📧 Feedback',
     'settings.about': 'About',
-    'settings.version': 'Version 1.3.0',
+    'settings.version': 'Version 1.3.1',
     'settings.license': 'License',
     'settings.licenseDetails': 'Open Source • MIT License\nNo commercial use without permission',
     'settings.settings': 'Settings',

--- a/src/screens/SettingsScreen.tsx
+++ b/src/screens/SettingsScreen.tsx
@@ -4,7 +4,7 @@ import { useTheme } from '../hooks/useTheme';
 import { storageService } from '../services/storage';
 import { useLanguage, PICKER_LANGUAGES } from '../contexts/LanguageContext';
 
-const APP_VERSION = '1.3.0';
+const APP_VERSION = '1.3.1';
 
 export const SettingsScreen: React.FC = () => {
   const { theme, themeMode, setThemeMode } = useTheme();


### PR DESCRIPTION
## Summary

- Bump version to 1.3.1 in all three required locations (`package.json`, `app.json`, `src/screens/SettingsScreen.tsx`)
- Update `settings.version` string in `LanguageContext.tsx` (de + en) to match
- Update `CLAUDE.md`: new Aktuelle Version header, PR #107 entry in Letzte Merges, `plantNames.ts` in Projektstruktur

## Test plan

- [ ] CI version consistency check passes (all three version files match)
- [ ] Settings screen shows "Version 1.3.1" in both DE and EN

https://claude.ai/code/session_01VDweFzzUMnsfrbih4j6GL8

---
_Generated by [Claude Code](https://claude.ai/code/session_01VDweFzzUMnsfrbih4j6GL8)_