### PR TITLE
fix: AgendaScreen-Lokalisierung + CLAUDE.md memory update

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,9 @@ Deploy: GitHub Pages via `gh-pages` unter `/Pflanzkalender/`
 
 ## Aktuelle Version: 1.3.1 (main)
 
-**Stand 2026-05-20:** User-Feedback (Issue #104, PR #107) + Lint Fix (Issue #108, PR #111) gemergt.
+**Stand 2026-05-20:** User-Feedback (Issue #104, PR #107) + Lint Fix (Issue #108, PR #111) + AgendaScreen-Lokalisierung (PR #113) gemergt.
 
-- **main branch:** v1.3.1 mit Phase 1 + Phase 2 (vollständig, inkl. Icon-Resizing) + Phase 3 (299 Tests) + Phase 4a (ESLint 9, Prettier) + Issue #56 Phase 3 (TypeScript-Cleanup, `TouchableWebProps`, Duplikat-Beseitigung) + Klima-Reiter (Issue #55, PR #80) + Splash Screen (Issue #99, PR #106) + User-Feedback (Issue #104, PR #107)
+- **main branch:** v1.3.1 mit Phase 1 + Phase 2 (vollständig, inkl. Icon-Resizing) + Phase 3 (299 Tests) + Phase 4a (ESLint 9, Prettier) + Issue #56 Phase 3 (TypeScript-Cleanup, `TouchableWebProps`, Duplikat-Beseitigung) + Klima-Reiter (Issue #55, PR #80) + Splash Screen (Issue #99, PR #106) + User-Feedback (Issue #104, PR #107) + AgendaScreen-Lokalisierung (PR #113)
 - **testing branch:** v1.3.1 (identisch mit main)
 
 Versions-Stellen: `package.json`, `app.json`, `src/screens/SettingsScreen.tsx` – immer alle drei synchron halten, sonst schlägt CI fehl.
@@ -243,6 +243,7 @@ Vollständige Roadmap: https://github.com/S540d/Pflanzkalender/issues/47
 
 | Was                                         | Wann       | Details                                                                                                                                                 |
 | ------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PR #113:** AgendaScreen-Lokalisierung     | 2026-05-20 | ✅ main `TBD`: `getPlantDisplayName(plant.name, language)` für Anzeige+Sortierung; `language` als `useCallback`-Dep                                     |
 | **PR #112:** Review PR #110 – v1.3.1 fixes  | 2026-05-20 | ✅ main `bb58f81`: Version-Bump 1.3.1, toter `settings.version`-Key entfernt, Versions-Test auf Semver-Pattern, CLAUDE.md Test-Count 299                |
 | **PR #111:** Issue #108 – Lint Fix          | 2026-05-19 | ✅ main `61125aa`: ESLint-Warnings 45 → 0 (allow console.error/warn, fix unused vars/types, disable exhaustive-deps, test-file-override for no-console) |
 | **PR #107:** Issue #104 – User-Feedback     | 2026-05-19 | ✅ main `f8a65f5`: Kalender-Zoom (3 Stufen), Pflanzen-Übersetzungen (`plantNames.ts`), Suchleiste in Pflanzenverwaltung, Tab-Overflow-Fix               |

--- a/src/screens/AgendaScreen.tsx
+++ b/src/screens/AgendaScreen.tsx
@@ -4,6 +4,7 @@ import { useTheme } from '../hooks/useTheme';
 import { usePlants } from '../contexts/PlantContext';
 import { useLanguage } from '../contexts/LanguageContext';
 import { CATEGORY_TABS, CategoryFilter } from '../constants/categoryTabs';
+import { getPlantDisplayName } from '../constants/plantNames';
 
 interface ActivityInfo {
   plantName: string;
@@ -45,7 +46,7 @@ export const AgendaScreen: React.FC = () => {
         plant.activities.forEach((activity) => {
           if (activity.startMonth <= monthIndex && activity.endMonth >= monthIndex) {
             activities.push({
-              plantName: plant.name,
+              plantName: getPlantDisplayName(plant.name, language),
               activityLabel: activity.label,
               activityColor: activity.color,
               notes: plant.notes,
@@ -54,9 +55,9 @@ export const AgendaScreen: React.FC = () => {
         });
       });
 
-      return activities.sort((a, b) => a.plantName.localeCompare(b.plantName, 'de'));
+      return activities.sort((a, b) => a.plantName.localeCompare(b.plantName, language));
     },
-    [filteredPlants]
+    [filteredPlants, language]
   );
 
   const previousActivities = useMemo(


### PR DESCRIPTION
## Summary

- **Fix**: `AgendaScreen` zeigt Pflanzennamen jetzt über `getPlantDisplayName(plant.name, language)` an — Default-Pflanzen erscheinen in EN-Locale korrekt auf Englisch (war: immer Deutsch). `localeCompare` nutzt ebenfalls die aktive Sprache statt festem `'de'`.
- **Docs**: `CLAUDE.md` auf Stand 2026-05-20 gebracht (v1.3.1, PR #113 in Letzte Merges).

## Test plan

- [ ] Sprache auf EN → Pflanzennamen in der Agenda auf Englisch
- [ ] Sprache auf DE → deutsche Namen
- [ ] Sortierung in beiden Sprachen korrekt alphabetisch

https://claude.ai/code/session_01S6sQ3AdraHLz6PyqLkZ2jT

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6sQ3AdraHLz6PyqLkZ2jT)_