### PR TITLE
fix: Kategorie-Migration für gespeicherte Default-Pflanzen

### DIFF
--- a/__tests__/contexts/PlantContext.test.tsx
+++ b/__tests__/contexts/PlantContext.test.tsx
@@ -79,6 +79,66 @@ describe('PlantContext – initial load', () => {
 
     expect(result.current.plants).toEqual([]);
   });
+
+  it('backfills category and location for saved default plants missing those fields', async () => {
+    // Simulates a plant saved before category/location were introduced (v1.3.0)
+    const legacyPlants = [
+      {
+        id: 'default-4', // index 4 = Rosen (category: 'flower', location: 'sun')
+        name: 'Rosen',
+        activities: [],
+        isDefault: true,
+        userId: null,
+        notes: '',
+        createdAt: 1000,
+        updatedAt: 1000,
+        // category and location intentionally absent
+      },
+    ];
+    mockGetItem.mockImplementation((key: string) =>
+      key === '@Pflanzkalender:plants'
+        ? Promise.resolve(JSON.stringify(legacyPlants))
+        : Promise.resolve(null)
+    );
+
+    const { result } = renderHook(() => usePlants(), { wrapper });
+    await waitForLoaded(result);
+
+    const rosen = result.current.plants.find((p) => p.id === 'default-4');
+    expect(rosen).toBeTruthy();
+    expect(rosen!.category).toBe('flower');
+    expect(rosen!.location).toBe('sun');
+    // Migration must persist the enriched data
+    expect(mockSetItem).toHaveBeenCalled();
+  });
+
+  it('does not re-save if no default plants need migration', async () => {
+    // Plant already has category and location – no save should happen
+    const upToDatePlants = [
+      {
+        id: 'default-4',
+        name: 'Rosen',
+        activities: [],
+        isDefault: true,
+        userId: null,
+        notes: '',
+        createdAt: 1000,
+        updatedAt: 1000,
+        category: 'flower',
+        location: 'sun',
+      },
+    ];
+    mockGetItem.mockImplementation((key: string) =>
+      key === '@Pflanzkalender:plants'
+        ? Promise.resolve(JSON.stringify(upToDatePlants))
+        : Promise.resolve(null)
+    );
+
+    const { result } = renderHook(() => usePlants(), { wrapper });
+    await waitForLoaded(result);
+
+    expect(mockSetItem).not.toHaveBeenCalled();
+  });
 });
 
 describe('PlantContext – addPlant', () => {

--- a/__tests__/contexts/PlantContext.test.tsx
+++ b/__tests__/contexts/PlantContext.test.tsx
@@ -108,8 +108,15 @@ describe('PlantContext – initial load', () => {
     expect(rosen).toBeTruthy();
     expect(rosen!.category).toBe('flower');
     expect(rosen!.location).toBe('sun');
-    // Migration must persist the enriched data
-    expect(mockSetItem).toHaveBeenCalled();
+    // Migration must persist the enriched data to the correct key with correct values
+    expect(mockSetItem).toHaveBeenCalledWith(
+      '@Pflanzkalender:plants',
+      expect.stringContaining('"category":"flower"')
+    );
+    expect(mockSetItem).toHaveBeenCalledWith(
+      '@Pflanzkalender:plants',
+      expect.stringContaining('"location":"sun"')
+    );
   });
 
   it('does not re-save if no default plants need migration', async () => {

--- a/src/contexts/PlantContext.tsx
+++ b/src/contexts/PlantContext.tsx
@@ -50,7 +50,28 @@ export const PlantProvider: React.FC<PlantProviderProps> = ({ children }) => {
           setPlants(defaultPlants);
           await storageService.savePlants(defaultPlants);
         } else {
-          setPlants(savedPlants);
+          // Migration: Default-Pflanzen ohne category/location mit aktuellen Metadaten anreichern
+          const migrated = savedPlants.map((plant) => {
+            if (!plant.isDefault) return plant;
+            const match = /^default-(\d+)$/.exec(plant.id);
+            if (!match) return plant;
+            const source = DEFAULT_PLANTS[parseInt(match[1], 10)];
+            if (!source) return plant;
+            let changed = false;
+            const updates: Partial<Plant> = {};
+            if (plant.category === undefined && source.category !== undefined) {
+              updates.category = source.category;
+              changed = true;
+            }
+            if (plant.location === undefined && source.location !== undefined) {
+              updates.location = source.location;
+              changed = true;
+            }
+            return changed ? { ...plant, ...updates } : plant;
+          });
+          const needsSave = migrated.some((p, i) => p !== savedPlants[i]);
+          setPlants(migrated);
+          if (needsSave) await storageService.savePlants(migrated);
         }
       } catch (error) {
         if (error instanceof Error && error.message === 'STORAGE_CORRUPTED') {


### PR DESCRIPTION
## Problem

Pflanzen, die vor Einführung von `category` und `location` (v1.3.0) in AsyncStorage gespeichert wurden, haben diese Felder nicht. Der Kategorie-Filter in der Pflanzenverwaltung (Blumen, Bäume, Nutzpflanzen) griff deshalb nicht – Blumen erschienen unter „Alle", aber nicht unter „Blumen".

## Ursache

Die Filterlogik (`plant.category ?? 'vegetable'`) behandelt `undefined` als Gemüse – korrekt für neu angelegte Pflanzen ohne Kategorie, aber falsch für Default-Pflanzen wie Rosen oder Tulpen, deren `category: 'flower'` schlicht nicht im Storage stand.

## Lösung

In `PlantContext.initializePlants`: Beim Laden werden Default-Pflanzen (erkennbar via Regex `^default-(\d+)$` + `isDefault: true`) mit `category` und `location` aus `DEFAULT_PLANTS` angereichert, falls diese Felder fehlen. Die migrierten Daten werden einmalig zurück in den Storage geschrieben.

## Adressierte Copilot-Suggestions

- ✅ Regex `^default-(\d+)$` statt `parseInt(replace())` für sichere ID-Extraktion
- ✅ 2 neue Tests: Backfill-Verhalten + kein unnötiges Re-Save wenn bereits aktuell

## Tests

- 306 Tests grün (vorher 304)
- Kein TypeScript-Fehler durch die Änderung eingeführt

🤖 Generated with [Claude Code](https://claude.com/claude-code)