### PR TITLE
fix: TypeScript-Fehler beheben – eslint.config.js aus tsconfig ausschließen (Issue #126)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,5 +2,6 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true
-  }
+  },
+  "exclude": ["eslint.config.js", "node_modules"]
 }


### PR DESCRIPTION
## Zusammenfassung

Schließt #126

- `testing`-Branch wurde von `main` neu synchronisiert (war nicht vorhanden)
- `eslint.config.js` wird jetzt via `exclude` aus dem TypeScript-Compile-Scope ausgeschlossen

## Problem

`npx tsc --noEmit` schlug mit zwei Fehlern fehl:

1. **TS7016** (`eslint.config.js:7`): `eslint-config-prettier` hat keine TypeScript-Typen und `@types/eslint-config-prettier` existiert nicht auf npm. Da `eslint.config.js` keine App-Datei ist, wird sie nun aus `tsconfig.json` ausgeschlossen.
2. **TS2769** (`SettingsModal.tsx:43`): `presentationStyle='none'` war kein gültiger Wert — war bereits in `main` behoben (`undefined`).

## Änderungen

- `tsconfig.json`: `"exclude": ["eslint.config.js", "node_modules"]` hinzugefügt

## Testplan

- [ ] `npx tsc --noEmit` zeigt keinen TS7016-Fehler mehr für `eslint.config.js`
- [ ] CI läuft grün durch
- [ ] Kein Einfluss auf App-Code oder Tests

https://claude.ai/code/session_01YCUXBC1hZJZy8E6cvXk3gR

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCUXBC1hZJZy8E6cvXk3gR)_