### PR TITLE
feat(#87): Import-UI für Pflanzendaten (JSON) im SettingsModal

### DIFF
--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -3,6 +3,7 @@ import { Alert } from 'react-native';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { SettingsScreen } from '../../src/screens/SettingsScreen';
 import { LanguageProvider } from '../../src/contexts/LanguageContext';
+import { PlantProvider } from '../../src/contexts/PlantContext';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const mockSetThemeMode = jest.fn();
@@ -35,6 +36,7 @@ jest.mock('../../src/services/storage', () => ({
   storageService: {
     exportPlants: jest.fn().mockResolvedValue(undefined),
     loadPlants: jest.fn().mockResolvedValue([]),
+    importPlants: jest.fn(),
   },
 }));
 
@@ -45,7 +47,11 @@ jest.mock('react-native/Libraries/Linking/Linking', () => ({
 jest.mock('@react-native-async-storage/async-storage');
 
 const renderWithProviders = (ui: React.ReactElement) =>
-  render(<LanguageProvider>{ui}</LanguageProvider>);
+  render(
+    <LanguageProvider>
+      <PlantProvider>{ui}</PlantProvider>
+    </LanguageProvider>
+  );
 
 describe('SettingsScreen', () => {
   beforeEach(() => {
@@ -162,5 +168,27 @@ describe('SettingsScreen', () => {
 
   it('is a valid React component', () => {
     expect(typeof SettingsScreen).toBe('function');
+  });
+
+  it('renders the import section', () => {
+    const { getByText } = renderWithProviders(<SettingsScreen />);
+    expect(getByText(/IMPORTIEREN|IMPORT/)).toBeTruthy();
+  });
+
+  it('renders the import button', () => {
+    const { getByText } = renderWithProviders(<SettingsScreen />);
+    expect(getByText(/Aus JSON importieren|Import from JSON/)).toBeTruthy();
+  });
+
+  it('shows a native-only alert when import button is pressed on non-web platform', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert');
+    const { getByText } = renderWithProviders(<SettingsScreen />);
+    fireEvent.press(getByText(/Aus JSON importieren|Import from JSON/));
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/Aus JSON importieren|Import from JSON/),
+        expect.stringMatching(/Browser|browser/)
+      );
+    });
   });
 });

--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -36,6 +36,7 @@ jest.mock('../../src/services/storage', () => ({
   storageService: {
     exportPlants: jest.fn().mockResolvedValue(undefined),
     loadPlants: jest.fn().mockResolvedValue([]),
+    savePlants: jest.fn().mockResolvedValue(undefined),
     importPlants: jest.fn(),
   },
 }));

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -99,6 +99,8 @@ module.exports = [
         alert: 'readonly',
         MediaQueryList: 'readonly',
         MediaQueryListEvent: 'readonly',
+        Event: 'readonly',
+        HTMLInputElement: 'readonly',
         __DEV__: 'readonly',
         caches: 'readonly',
       },

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -44,6 +44,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onClose }
       return;
     }
     // platform-safe: document only available in web context
+    if (typeof document === 'undefined') return;
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = '.json,application/json';
@@ -72,10 +73,7 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onClose }
           },
         ]);
       } catch (error) {
-        Alert.alert(
-          t('settings.importConfirmTitle') as string,
-          t('settings.importError') as string
-        );
+        Alert.alert(t('settings.importData') as string, t('settings.importError') as string);
         console.error('Import error:', error);
       }
       (e.target as HTMLInputElement).value = '';

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -13,6 +13,7 @@ import {
 import { useTheme } from '../hooks/useTheme';
 import { storageService } from '../services/storage';
 import { useLanguage, PICKER_LANGUAGES } from '../contexts/LanguageContext';
+import { usePlants } from '../contexts/PlantContext';
 import packageJson from '../../package.json';
 
 interface SettingsModalProps {
@@ -25,6 +26,7 @@ const APP_VERSION = packageJson.version;
 export const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onClose }) => {
   const { theme, themeMode, setThemeMode } = useTheme();
   const { language, setLanguage, t } = useLanguage();
+  const { replacePlants } = usePlants();
 
   const handleExport = async () => {
     try {
@@ -34,6 +36,51 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onClose }
       Alert.alert('Error', 'Failed to export data. Please try again.');
       console.error('Export error:', error);
     }
+  };
+
+  const handleImport = () => {
+    if (Platform.OS !== 'web') {
+      Alert.alert(t('settings.importData') as string, t('settings.importWebOnly') as string);
+      return;
+    }
+    // platform-safe: document only available in web context
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json,application/json';
+    input.onchange = async (e: Event) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (!file) return;
+      try {
+        const text = await file.text();
+        const imported = await storageService.importPlants(text);
+        const msg = (t('settings.importConfirmMessage') as string).replace(
+          '{count}',
+          String(imported.length)
+        );
+        Alert.alert(t('settings.importConfirmTitle') as string, msg, [
+          { text: t('settings.importConfirmCancel') as string, style: 'cancel' },
+          {
+            text: t('settings.importConfirmOk') as string,
+            onPress: () => {
+              replacePlants(imported);
+              const successMsg = (t('settings.importSuccess') as string).replace(
+                '{count}',
+                String(imported.length)
+              );
+              Alert.alert(t('settings.successTitle') as string, successMsg);
+            },
+          },
+        ]);
+      } catch (error) {
+        Alert.alert(
+          t('settings.importConfirmTitle') as string,
+          t('settings.importError') as string
+        );
+        console.error('Import error:', error);
+      }
+      (e.target as HTMLInputElement).value = '';
+    };
+    input.click();
   };
 
   return (
@@ -173,6 +220,26 @@ export const SettingsModal: React.FC<SettingsModalProps> = ({ visible, onClose }
                 ]}
               >
                 {t('settings.exportData') as string}
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          <View style={[styles.separator, { backgroundColor: theme.border }]} />
+
+          {/* Import Section */}
+          <View style={styles.section}>
+            <Text style={[styles.sectionTitle, { color: theme.textSecondary }]}>
+              {t('settings.importSection') as string}
+            </Text>
+            <TouchableOpacity
+              style={[
+                styles.exportButton,
+                { backgroundColor: theme.surface, borderWidth: 1, borderColor: theme.border },
+              ]}
+              onPress={handleImport}
+            >
+              <Text style={[styles.exportButtonText, { color: theme.text }]}>
+                {t('settings.importData') as string}
               </Text>
             </TouchableOpacity>
           </View>

--- a/src/contexts/PlantContext.tsx
+++ b/src/contexts/PlantContext.tsx
@@ -14,6 +14,7 @@ interface PlantContextType {
   updateActivity: (plantId: string, activityId: string, updates: Partial<Activity>) => void;
   deleteActivity: (plantId: string, activityId: string) => void;
   resetToDefaults: () => void;
+  replacePlants: (plants: Plant[]) => void;
 }
 
 const PlantContext = createContext<PlantContextType | undefined>(undefined);
@@ -179,6 +180,10 @@ export const PlantProvider: React.FC<PlantProviderProps> = ({ children }) => {
     await savePlants(defaultPlants);
   };
 
+  const replacePlants = (newPlants: Plant[]) => {
+    void savePlants(newPlants);
+  };
+
   return (
     <PlantContext.Provider
       value={{
@@ -191,6 +196,7 @@ export const PlantProvider: React.FC<PlantProviderProps> = ({ children }) => {
         updateActivity,
         deleteActivity,
         resetToDefaults,
+        replacePlants,
       }}
     >
       {children}

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -128,6 +128,17 @@ const de: Translations = {
   'activity.type.harvest': 'Ernten',
   'activity.type.protect': 'Winterschutz',
   'activity.type.mulch': 'Mulchen',
+
+  // Import
+  'settings.importSection': 'IMPORTIEREN',
+  'settings.importData': 'Aus JSON importieren',
+  'settings.importConfirmTitle': 'Import bestätigen',
+  'settings.importConfirmMessage': '{count} Pflanzen importieren? Bestehende Daten werden ersetzt.',
+  'settings.importConfirmOk': 'Importieren',
+  'settings.importConfirmCancel': 'Abbrechen',
+  'settings.importSuccess': '{count} Pflanzen erfolgreich importiert.',
+  'settings.importError': 'Import fehlgeschlagen. Bitte prüfe das Dateiformat.',
+  'settings.importWebOnly': 'Import ist nur im Browser verfügbar.',
 };
 
 export default de;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -127,6 +127,17 @@ const en: Translations = {
   'activity.type.harvest': 'Harvest',
   'activity.type.protect': 'Winter protection',
   'activity.type.mulch': 'Mulch',
+
+  // Import
+  'settings.importSection': 'IMPORT',
+  'settings.importData': 'Import from JSON',
+  'settings.importConfirmTitle': 'Confirm Import',
+  'settings.importConfirmMessage': 'Import {count} plants? Existing data will be replaced.',
+  'settings.importConfirmOk': 'Import',
+  'settings.importConfirmCancel': 'Cancel',
+  'settings.importSuccess': '{count} plants successfully imported.',
+  'settings.importError': 'Import failed. Please check the file format.',
+  'settings.importWebOnly': 'Import is only available in the browser.',
 };
 
 export default en;

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -108,6 +108,18 @@ const es: Translations = {
   'activity.type.harvest': 'Cosechar',
   'activity.type.protect': 'Protección invernal',
   'activity.type.mulch': 'Acolchar',
+
+  // Import
+  'settings.importSection': 'IMPORTAR',
+  'settings.importData': 'Importar desde JSON',
+  'settings.importConfirmTitle': 'Confirmar importación',
+  'settings.importConfirmMessage':
+    '¿Importar {count} plantas? Los datos existentes serán reemplazados.',
+  'settings.importConfirmOk': 'Importar',
+  'settings.importConfirmCancel': 'Cancelar',
+  'settings.importSuccess': '{count} plantas importadas correctamente.',
+  'settings.importError': 'Error al importar. Comprueba el formato del archivo.',
+  'settings.importWebOnly': 'La importación solo está disponible en el navegador.',
 };
 
 export default es;

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -108,6 +108,18 @@ const fr: Translations = {
   'activity.type.harvest': 'Récolter',
   'activity.type.protect': 'Protection hivernale',
   'activity.type.mulch': 'Pailler',
+
+  // Import
+  'settings.importSection': 'IMPORTER',
+  'settings.importData': 'Importer depuis JSON',
+  'settings.importConfirmTitle': "Confirmer l'importation",
+  'settings.importConfirmMessage':
+    'Importer {count} plantes ? Les données existantes seront remplacées.',
+  'settings.importConfirmOk': 'Importer',
+  'settings.importConfirmCancel': 'Annuler',
+  'settings.importSuccess': '{count} plantes importées avec succès.',
+  'settings.importError': 'Importation échouée. Veuillez vérifier le format du fichier.',
+  'settings.importWebOnly': "L'importation n'est disponible que dans le navigateur.",
 };
 
 export default fr;

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -108,6 +108,18 @@ const it: Translations = {
   'activity.type.harvest': 'Raccogliere',
   'activity.type.protect': 'Protezione invernale',
   'activity.type.mulch': 'Pacciamatura',
+
+  // Import
+  'settings.importSection': 'IMPORTARE',
+  'settings.importData': 'Importa da JSON',
+  'settings.importConfirmTitle': 'Conferma importazione',
+  'settings.importConfirmMessage':
+    'Importare {count} piante? I dati esistenti verranno sostituiti.',
+  'settings.importConfirmOk': 'Importa',
+  'settings.importConfirmCancel': 'Annulla',
+  'settings.importSuccess': '{count} piante importate con successo.',
+  'settings.importError': 'Importazione fallita. Verifica il formato del file.',
+  'settings.importWebOnly': "L'importazione è disponibile solo nel browser.",
 };
 
 export default it;

--- a/src/i18n/nl.ts
+++ b/src/i18n/nl.ts
@@ -108,6 +108,18 @@ const nl: Translations = {
   'activity.type.harvest': 'Oogsten',
   'activity.type.protect': 'Winterbescherming',
   'activity.type.mulch': 'Mulchen',
+
+  // Import
+  'settings.importSection': 'IMPORTEREN',
+  'settings.importData': 'Importeren vanuit JSON',
+  'settings.importConfirmTitle': 'Importeren bevestigen',
+  'settings.importConfirmMessage':
+    '{count} planten importeren? Bestaande gegevens worden vervangen.',
+  'settings.importConfirmOk': 'Importeren',
+  'settings.importConfirmCancel': 'Annuleren',
+  'settings.importSuccess': '{count} planten succesvol geïmporteerd.',
+  'settings.importError': 'Import mislukt. Controleer het bestandsformaat.',
+  'settings.importWebOnly': 'Importeren is alleen beschikbaar in de browser.',
 };
 
 export default nl;

--- a/src/i18n/pl.ts
+++ b/src/i18n/pl.ts
@@ -108,6 +108,17 @@ const pl: Translations = {
   'activity.type.harvest': 'Zbierać',
   'activity.type.protect': 'Ochrona zimowa',
   'activity.type.mulch': 'Ściółkować',
+
+  // Import
+  'settings.importSection': 'IMPORTUJ',
+  'settings.importData': 'Importuj z JSON',
+  'settings.importConfirmTitle': 'Potwierdź import',
+  'settings.importConfirmMessage': 'Importować {count} roślin? Istniejące dane zostaną zastąpione.',
+  'settings.importConfirmOk': 'Importuj',
+  'settings.importConfirmCancel': 'Anuluj',
+  'settings.importSuccess': '{count} roślin zaimportowanych pomyślnie.',
+  'settings.importError': 'Import nie powiódł się. Sprawdź format pliku.',
+  'settings.importWebOnly': 'Import jest dostępny tylko w przeglądarce.',
 };
 
 export default pl;

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -108,6 +108,18 @@ const pt: Translations = {
   'activity.type.harvest': 'Colher',
   'activity.type.protect': 'Proteção invernal',
   'activity.type.mulch': 'Mulchar',
+
+  // Import
+  'settings.importSection': 'IMPORTAR',
+  'settings.importData': 'Importar de JSON',
+  'settings.importConfirmTitle': 'Confirmar importação',
+  'settings.importConfirmMessage':
+    'Importar {count} plantas? Os dados existentes serão substituídos.',
+  'settings.importConfirmOk': 'Importar',
+  'settings.importConfirmCancel': 'Cancelar',
+  'settings.importSuccess': '{count} plantas importadas com sucesso.',
+  'settings.importError': 'Importação falhou. Verifique o formato do arquivo.',
+  'settings.importWebOnly': 'A importação só está disponível no navegador.',
 };
 
 export default pt;


### PR DESCRIPTION
Closes #87

## Änderungen

### PlantContext
- `replacePlants(plants: Plant[]) => void` hinzugefügt – ersetzt den kompletten Pflanzenbestand und speichert ihn via `storageService`

### SettingsModal – neue Import-Sektion
- **Web (PWA):** nativer File-Picker via `document.createElement('input')` (platform-safe guard), akzeptiert `.json`
- **Native:** Alert mit Hinweis "nur im Browser verfügbar" (kein expo-document-picker nötig)
- **Flow:** Datei auswählen → `storageService.importPlants()` validiert (Zod) → Confirm-Alert mit Pflanzenanzahl und Überschreib-Warnung → bei Bestätigung `replacePlants()` → Erfolgs-Alert
- **Fehlerfall:** Ungültiges Format oder Validierungsfehler werden per Alert angezeigt

### i18n
9 neue Schlüssel (`settings.import*`) in allen 8 Sprachen (DE, EN, FR, ES, IT, PL, NL, PT):
`importSection`, `importData`, `importConfirmTitle`, `importConfirmMessage`, `importConfirmOk`, `importConfirmCancel`, `importSuccess`, `importError`, `importWebOnly`

### Tests
- `SettingsScreen.test.tsx`: `PlantProvider` zum Wrapper hinzugefügt, `importPlants` in Storage-Mock, 3 neue Tests (Import-Sektion sichtbar, Button sichtbar, Native-Alert)

## Test plan
- [x] `npx tsc --noEmit` → 0 Fehler
- [x] 341 Tests grün (vorher 338)
- [x] Prettier + pre-commit hooks grün
- [ ] CI auf GitHub Actions
- [ ] Manuell: JSON-Export aus der App herunterladen, dann wieder importieren

---
_Generated by [Claude Code](https://claude.ai/code/session_01FN5KY7R46sDfLeySNwWKyx)_