### PR TITLE
merge: testing → main (Issue #8 Template-System + #88 Export-Fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,10 +32,10 @@ Deploy: GitHub Pages via `gh-pages` unter `/Pflanzkalender/`
 
 ## Aktuelle Version: 1.4.0 (main)
 
-**Stand 2026-05-24:** main = v1.4.0 (versionCode 5). testing ist hinter main (noch v1.3.2). Keine offenen PRs.
+**Stand 2026-05-29:** main = v1.4.0 (versionCode 5). testing = v1.4.0 + Issue #8 (Template-System, PR #147 gemergt).
 
 - **main branch:** v1.4.0 – Issues #122 + #126 geschlossen, APK + AAB gebaut und signiert
-- **testing branch:** hinter main (Stand 2026-05-24) – noch v1.3.2
+- **testing branch:** v1.4.0 + PR #147 (Issue #8 Template-System, Commit `ad4c9fb`)
 
 Versions-Stellen: `package.json`, `app.json`, `twa-manifest.template.json` – immer alle drei synchron halten, sonst schlägt CI fehl. `SettingsScreen.tsx` liest Version jetzt dynamisch aus `package.json` (seit PR #124), kein manuelles Sync mehr nötig.
 
@@ -45,15 +45,16 @@ Versions-Stellen: `package.json`, `app.json`, `twa-manifest.template.json` – i
 
 ```
 app/                           # Expo Router (file-based routing, Phase 4b)
-  _layout.tsx                  # Root: ErrorBoundary/Language/Plant Provider + Bottom-Tabs
-  index.tsx                    # /         → CalendarScreen
-  agenda.tsx                   # /agenda   → AgendaScreen
-  plants.tsx                   # /plants   → PlantManagementScreen
-  climate.tsx                  # /climate  → ClimateScreen
-  settings.tsx                 # /settings → SettingsScreen
+  _layout.tsx                  # Root: ErrorBoundary/Language/Plant Provider + Bottom-Tabs (6 Tabs)
+  index.tsx                    # /           → CalendarScreen
+  agenda.tsx                   # /agenda     → AgendaScreen
+  plants.tsx                   # /plants     → PlantManagementScreen
+  climate.tsx                  # /climate    → ClimateScreen
+  templates.tsx                # /templates  → TemplateScreen (Issue #8, seit PR #147)
+  settings.tsx                 # /settings   → SettingsScreen
 app.config.js                  # Dynamische Expo-Config: expo-router plugin, web.output=single, experiments.baseUrl (Prod/Testing)
 src/
-  screens/                     # CalendarScreen, AgendaScreen, PlantManagementScreen, ClimateScreen, SettingsScreen
+  screens/                     # CalendarScreen, AgendaScreen, PlantManagementScreen, ClimateScreen, SettingsScreen, TemplateScreen
   components/                  # ActivityBar, PlantRow, AddActivityModal, EditActivityModal, AddPlantModal, AppHeader, Footer, ErrorBoundary
   contexts/                    # PlantContext (CRUD), LanguageContext (de/en)
   hooks/                       # useTheme (Dark/Light/System)
@@ -62,9 +63,11 @@ src/
     activityTypes.ts           # Aktivitätstypen mit Farben
     plantMetadata.ts           # PLANT_LOCATION_METADATA + PLANT_CATEGORY_METADATA (Single Source of Truth)
     plantNames.ts              # PLANT_NAME_EN + getPlantDisplayName() – DE↔EN Übersetzung für Pflanzennamen
+    communityTemplates.ts      # 3 Community-Templates (Balkon-Starter, Gemüsegarten, Kräutergarten) – seit PR #147
     theme.ts                   # Farbpalette
   services/
-    storage.ts                 # AsyncStorage Wrapper
+    storage.ts                 # AsyncStorage Wrapper (inkl. exportPlants/importPlants)
+    templateService.ts         # Export/Import Logik: buildExportJson, triggerWebDownload, sharePlants, importFromJson – seit PR #147
     firebase.ts                # Firebase Init (Placeholder)
   types/index.ts               # Plant, Activity, User, PlantLocation, PlantCategory
   utils/                       # activityLayout, monthHelper
@@ -136,7 +139,9 @@ Drei Stellen müssen immer identisch sein:
 
 ### Platform Safety
 
-`window.*` und `localStorage` nur mit `Platform.OS === 'web'` Guard oder Kommentar `// platform-safe`. React Native hat ein `window`-Objekt, aber nicht alle Web-APIs.
+`window.*`, `document.*`, `localStorage`, `Blob`, `FileReader` nur mit `Platform.OS === 'web'` Guard oder Kommentar `// platform-safe`. React Native hat ein `window`-Objekt, aber nicht alle Web-APIs.
+
+Die ESLint-Globals in `eslint.config.js` enthalten Browser-APIs (`Blob`, `FileReader`, `document`, `alert` u. a.) – diese werden ausschließlich innerhalb von `Platform.OS === 'web'`-Guards verwendet.
 
 ### PlantLocation / PlantCategory Typen
 
@@ -245,15 +250,15 @@ Vollständige Roadmap: https://github.com/S540d/Pflanzkalender/issues/47
 
 ---
 
-## Offene Issues (Stand 2026-05-24)
+## Offene Issues (Stand 2026-05-29)
 
-**Status: main = v1.4.0, APK/AAB gebaut. testing hinter main. Keine offenen PRs.**
+**Status: main = v1.4.0, APK/AAB gebaut. testing = v1.4.0 + Issue #8 (PR #147 gemergt). 348 Tests grün.**
 
 ### v1.4.0 – abgeschlossen / Play Store
 
 - **#126** ✅ Geschlossen (PR #144 gemergt)
 - **#122** ✅ Geschlossen (PR #145 gemergt)
-- **#88** Bug: Data export kein File-Download auf Web (PWA) – **priority: high**
+- **#88** Bug: Data export kein File-Download auf Web (PWA) – **priority: high** (teilweise durch PR #147 adressiert: Web-Download via `<a>`-Element in `templateService.ts`; Settings-Export nutzt noch Share API)
 - **#123** Code-Audit: Wartbarkeit & Security – Referenz-Issue mit Action Items
 
 ### v1.5.0 – Content & Personalisierung
@@ -267,7 +272,7 @@ Vollständige Roadmap: https://github.com/S540d/Pflanzkalender/issues/47
 
 - **#48** Klimazonen-Unterstützung – unterschiedliche Aktivitätszeiträume je Region
 - **#142** Drag & Drop für Aktivitäten im Kalender
-- **#8** Template-System: Pflanzpläne teilen und importieren
+- **#8** ✅ Template-System: Pflanzpläne teilen und importieren – **in testing** (PR #147, Commit `ad4c9fb`)
 - **#9** Intelligente Vorschläge: Fruchtfolge & Mischkultur
 
 ## Abgeschlossene Roadmap-Issues
@@ -276,10 +281,11 @@ Vollständige Roadmap: https://github.com/S540d/Pflanzkalender/issues/47
 
 ---
 
-## Letzte Merges / Fixes (2026-05-24)
+## Letzte Merges / Fixes (2026-05-29)
 
 | Was                                          | Wann       | Details                                                                                                                                                 |
 | -------------------------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PR #147:** Issue #8 – Template-System      | 2026-05-29 | ✅ testing `ad4c9fb`: TemplateScreen (3 Sections), 3 Community-Templates, templateService (Web-Download + Share), 348 Tests grün                        |
 | **v1.4.0 Bump + APK/AAB**                    | 2026-05-24 | ✅ main `b4627eb`: Version 1.4.0 / versionCode 5; APK + AAB gebaut & signiert; APK auf Testgerät installiert                                            |
 | **PR #145:** Issue #122 – expo-router Mock   | 2026-05-24 | ✅ gemergt: `__mocks__/expo-router.js` globaler Mock, per-file Boilerplate entfernt, 326 Tests grün                                                     |
 | **PR #144:** Issue #126 – TS-Fehler          | 2026-05-24 | ✅ gemergt: `App_BACKUP.tsx` entfernt, `tsc --noEmit` sauber (Exit 0)                                                                                   |
@@ -315,4 +321,4 @@ ESLint-Warnings 45 → **0** via:
 - **ESLint-Config**: `no-console: allow: ['error', 'warn']`, Test-Override `no-console: off`, `varsIgnorePattern: '^_'` für no-unused-vars
 - **Test-Dateien**: Ungenutzte Imports/Variablen entfernt, `any` → konkrete Typen in Mocks
 - **Produktionscode**: `console.error` intentional, unused params `_` prefixed, `exhaustive-deps` Block-Disable wo Deps redundant
-- **Ergebnis**: 0 Warnings lokal, Prettier clean, 299 Tests grün
+- **Ergebnis**: 0 Warnings lokal, Prettier clean, 299 Tests grün (Stand 2026-05-29: 348)

--- a/__tests__/screens/TemplateScreen.test.tsx
+++ b/__tests__/screens/TemplateScreen.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { Alert } from 'react-native';
+import { TemplateScreen } from '../../src/screens/TemplateScreen';
+import { LanguageProvider } from '../../src/contexts/LanguageContext';
+import { PlantProvider } from '../../src/contexts/PlantContext';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+jest.mock('../../src/services/templateService', () => ({
+  sharePlants: jest.fn().mockResolvedValue(undefined),
+  importFromJson: jest.fn(),
+}));
+
+jest.mock('../../src/hooks/useTheme', () => ({
+  useTheme: () => ({
+    theme: {
+      background: '#fff',
+      text: '#000',
+      textSecondary: '#666',
+      border: '#ddd',
+      surface: '#f5f5f5',
+      primary: '#4CAF50',
+      error: '#f44336',
+    },
+    isDark: false,
+  }),
+}));
+
+jest.mock('@react-native-async-storage/async-storage');
+
+const Providers: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+  <LanguageProvider>
+    <PlantProvider>{children}</PlantProvider>
+  </LanguageProvider>
+);
+
+const renderScreen = () => render(<TemplateScreen />, { wrapper: Providers });
+
+describe('TemplateScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (AsyncStorage.getItem as jest.Mock).mockImplementation(() => Promise.resolve(null));
+    (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    (AsyncStorage.multiRemove as jest.Mock).mockResolvedValue(undefined);
+  });
+
+  it('renders without crashing', () => {
+    const { root } = renderScreen();
+    expect(root).toBeTruthy();
+  });
+
+  it('renders the title text', () => {
+    const { getAllByText } = renderScreen();
+    // Title "Vorlagen" also appears as a tab label
+    expect(getAllByText(/^Vorlagen$|^Templates$/).length).toBeGreaterThan(0);
+  });
+
+  it('shows community templates by default', () => {
+    const { getByText } = renderScreen();
+    expect(getByText(/Balkon-Garten Starter|Balcony Garden Starter/)).toBeTruthy();
+  });
+
+  it('shows all three community template cards', () => {
+    const { getByText } = renderScreen();
+    expect(getByText(/Balkon-Garten Starter|Balcony Garden Starter/)).toBeTruthy();
+    expect(getByText(/Gemüsegarten Anfänger|Vegetable Garden Beginner/)).toBeTruthy();
+    expect(getByText(/Kräutergarten|Herb Garden/)).toBeTruthy();
+  });
+
+  it('community template cards show plant names', () => {
+    const { getByText } = renderScreen();
+    expect(getByText(/Tomaten/)).toBeTruthy();
+    expect(getByText(/Salat/)).toBeTruthy();
+  });
+
+  it('switches to Export section on tab press', () => {
+    const { getByText } = renderScreen();
+    // "Exportieren" only appears once as the export section tab
+    fireEvent.press(getByText(/^Exportieren$|^Export$/));
+    expect(getByText(/^EXPORTIEREN$|^EXPORT$/)).toBeTruthy();
+  });
+
+  it('switches to Import section on tab press', async () => {
+    const { getAllByText, getByPlaceholderText } = renderScreen();
+    // Section tabs are rendered before card buttons, so index 0 is the section tab
+    const allImportLabels = getAllByText(/^Importieren$|^Import$/);
+    fireEvent.press(allImportLabels[0]);
+    await waitFor(() => {
+      expect(getByPlaceholderText(/JSON/i)).toBeTruthy();
+    });
+  });
+
+  it('shows at least 4 Import buttons (tab + 3 cards)', () => {
+    const { getAllByText } = renderScreen();
+    const importBtns = getAllByText(/^Importieren$|^Import$/);
+    expect(importBtns.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('shows alert when pressing a community template import button', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const { getAllByText } = renderScreen();
+    // [0] is the section tab, [1] is the first card's import button
+    const importBtns = getAllByText(/^Importieren$|^Import$/);
+    fireEvent.press(importBtns[1]);
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+    });
+    alertSpy.mockRestore();
+  });
+
+  it('shows alert when export is triggered with no plants', async () => {
+    const alertSpy = jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+    const { getByText } = renderScreen();
+    fireEvent.press(getByText(/^Exportieren$|^Export$/));
+    await waitFor(() => getByText(/^EXPORTIEREN$|^EXPORT$/));
+    fireEvent.press(getByText(/Pflanzen exportieren|plants export/));
+    await waitFor(() => {
+      expect(alertSpy).toHaveBeenCalled();
+    });
+    alertSpy.mockRestore();
+  });
+
+  it('renders JSON text input on import section', async () => {
+    const { getAllByText, getByPlaceholderText } = renderScreen();
+    const allImportLabels = getAllByText(/^Importieren$|^Import$/);
+    fireEvent.press(allImportLabels[0]);
+    await waitFor(() => {
+      expect(getByPlaceholderText(/JSON/i)).toBeTruthy();
+    });
+  });
+});

--- a/__tests__/services/storage.test.ts
+++ b/__tests__/services/storage.test.ts
@@ -143,6 +143,8 @@ describe('storageService.exportPlants', () => {
     g.document = origDocument;
     g.URL = origURL;
     g.Blob = origBlob;
+    // Restore real timers even if a test using fake timers failed before its own restore
+    jest.useRealTimers();
   });
 
   it('calls Share.share on native with valid JSON containing the plants', async () => {

--- a/__tests__/services/storage.test.ts
+++ b/__tests__/services/storage.test.ts
@@ -1,11 +1,21 @@
 import { storageService } from '../../src/services/storage';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { Share } from 'react-native';
 import type { Plant } from '../../src/types';
 
-jest.mock('react-native', () => ({
-  Share: { share: jest.fn() },
-}));
+const mockShareFn = jest.fn();
+
+jest.mock('react-native', () => {
+  const platformState = { OS: 'ios' };
+  return {
+    Share: { share: (...args: unknown[]) => mockShareFn(...args) },
+    Platform: platformState,
+    __platformState: platformState,
+  };
+});
+
+const { __platformState: mockPlatform } = require('react-native') as {
+  __platformState: { OS: string };
+};
 
 const makePlant = (id: string): Plant => ({
   id,
@@ -115,33 +125,113 @@ describe('storageService.clearAll', () => {
 });
 
 describe('storageService.exportPlants', () => {
+  const g = global as Record<string, unknown>;
+  let origDocument: unknown;
+  let origURL: unknown;
+  let origBlob: unknown;
+
   beforeEach(async () => {
     await AsyncStorage.clear();
     jest.clearAllMocks();
+    mockPlatform.OS = 'ios';
+    origDocument = g.document;
+    origURL = g.URL;
+    origBlob = g.Blob;
   });
 
-  it('calls Share.share with a JSON string containing the current plants', async () => {
+  afterEach(() => {
+    g.document = origDocument;
+    g.URL = origURL;
+    g.Blob = origBlob;
+  });
+
+  it('calls Share.share on native with valid JSON containing the plants', async () => {
+    mockPlatform.OS = 'ios';
     const plants = [makePlant('e1')];
     await storageService.savePlants(plants);
-    (Share.share as jest.Mock).mockResolvedValueOnce({ action: 'sharedAction' });
+    mockShareFn.mockResolvedValueOnce({ action: 'sharedAction' });
 
     await storageService.exportPlants();
 
-    expect(Share.share).toHaveBeenCalledTimes(1);
-    const callArg = (Share.share as jest.Mock).mock.calls[0][0];
+    expect(mockShareFn).toHaveBeenCalledTimes(1);
+    const callArg = mockShareFn.mock.calls[0][0];
     const parsed = JSON.parse(callArg.message);
     expect(parsed.plants).toHaveLength(1);
     expect(parsed.plants[0].id).toBe('e1');
     expect(parsed.version).toBe('1.0.0');
     expect(parsed.timestamp).toBeTruthy();
+    expect(callArg.title).toBe('pflanzkalender-export.json');
   });
 
-  it('does not throw when Share.share rejects (falls back to alert)', async () => {
-    global.alert = jest.fn();
-    await storageService.savePlants([]);
-    (Share.share as jest.Mock).mockRejectedValueOnce(new Error('share failed'));
-    await expect(storageService.exportPlants()).resolves.toBeUndefined();
-    expect(global.alert).toHaveBeenCalled();
+  it('triggers Blob download on web without calling Share.share', async () => {
+    mockPlatform.OS = 'web';
+    jest.useFakeTimers();
+    const plants = [makePlant('e2')];
+    await storageService.savePlants(plants);
+
+    const mockClick = jest.fn();
+    const mockAnchor = {
+      href: '',
+      download: '',
+      click: mockClick,
+      parentNode: null as unknown,
+    };
+    const mockCreateElement = jest.fn().mockReturnValue(mockAnchor);
+    const mockAppendChild = jest.fn();
+    const mockRemoveChild = jest.fn();
+    const mockUrl = 'blob:mock-url';
+    const mockCreateObjectURL = jest.fn().mockReturnValue(mockUrl);
+    const mockRevokeObjectURL = jest.fn();
+
+    g.document = {
+      createElement: mockCreateElement,
+      body: { appendChild: mockAppendChild, removeChild: mockRemoveChild },
+    };
+    g.URL = { createObjectURL: mockCreateObjectURL, revokeObjectURL: mockRevokeObjectURL };
+    g.Blob = jest.fn().mockReturnValue({});
+
+    await storageService.exportPlants();
+
+    expect(mockShareFn).not.toHaveBeenCalled();
+    expect(mockCreateElement).toHaveBeenCalledWith('a');
+    expect(mockAnchor.download).toBe('pflanzkalender-export.json');
+    expect(mockAnchor.href).toBe(mockUrl);
+    expect(mockAppendChild).toHaveBeenCalledWith(mockAnchor);
+    expect(mockClick).toHaveBeenCalled();
+    expect(mockRemoveChild).toHaveBeenCalledWith(mockAnchor);
+    // revokeObjectURL is deferred via setTimeout
+    expect(mockRevokeObjectURL).not.toHaveBeenCalled();
+    jest.runAllTimers();
+    expect(mockRevokeObjectURL).toHaveBeenCalledWith(mockUrl);
+
+    jest.useRealTimers();
+  });
+
+  it('web export Blob contains all plants and correct metadata', async () => {
+    mockPlatform.OS = 'web';
+    const plants = [makePlant('e3'), makePlant('e4')];
+    await storageService.savePlants(plants);
+
+    let capturedContent = '';
+    const mockCreateObjectURL = jest.fn().mockReturnValue('blob:x');
+    const mockRevokeObjectURL = jest.fn();
+
+    g.Blob = jest.fn().mockImplementation((parts: string[]) => {
+      capturedContent = parts[0];
+      return {};
+    });
+    g.document = {
+      createElement: jest.fn().mockReturnValue({ href: '', download: '', click: jest.fn() }),
+      body: { appendChild: jest.fn(), removeChild: jest.fn() },
+    };
+    g.URL = { createObjectURL: mockCreateObjectURL, revokeObjectURL: mockRevokeObjectURL };
+
+    await storageService.exportPlants();
+
+    const parsed = JSON.parse(capturedContent);
+    expect(parsed.version).toBe('1.0.0');
+    expect(parsed.plants).toHaveLength(2);
+    expect(parsed.plants.map((p: Plant) => p.id)).toEqual(['e3', 'e4']);
   });
 });
 

--- a/__tests__/services/templateService.test.ts
+++ b/__tests__/services/templateService.test.ts
@@ -1,0 +1,115 @@
+import { buildExportJson, importFromJson } from '../../src/services/templateService';
+import { Plant } from '../../src/types';
+
+const makePlant = (overrides: Partial<Plant> = {}): Plant => ({
+  id: 'plant-1',
+  name: 'Tomaten',
+  isDefault: false,
+  userId: null,
+  activities: [
+    {
+      id: 'sow-3-5',
+      type: 'sow',
+      startMonth: 3,
+      endMonth: 5,
+      color: '#8B4513',
+      label: 'Aussäen',
+    },
+  ],
+  notes: 'Testpflanze',
+  location: 'sun',
+  category: 'vegetable',
+  createdAt: 1000000,
+  updatedAt: 1000000,
+  ...overrides,
+});
+
+describe('buildExportJson', () => {
+  it('produces valid JSON with required fields', () => {
+    const plants = [makePlant()];
+    const json = buildExportJson(plants);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.version).toBe('1.0.0');
+    expect(typeof parsed.timestamp).toBe('string');
+    expect(Array.isArray(parsed.plants)).toBe(true);
+    expect(parsed.plants).toHaveLength(1);
+  });
+
+  it('includes all plant fields', () => {
+    const plant = makePlant();
+    const json = buildExportJson([plant]);
+    const parsed = JSON.parse(json);
+    const p = parsed.plants[0];
+
+    expect(p.id).toBe(plant.id);
+    expect(p.name).toBe(plant.name);
+    expect(p.activities).toHaveLength(1);
+    expect(p.notes).toBe(plant.notes);
+  });
+
+  it('handles empty plant array', () => {
+    const json = buildExportJson([]);
+    const parsed = JSON.parse(json);
+    expect(parsed.plants).toHaveLength(0);
+  });
+
+  it('produces pretty-printed JSON', () => {
+    const json = buildExportJson([makePlant()]);
+    expect(json).toContain('\n');
+  });
+
+  it('timestamp is a valid ISO 8601 string', () => {
+    const json = buildExportJson([]);
+    const { timestamp } = JSON.parse(json);
+    expect(() => new Date(timestamp)).not.toThrow();
+    expect(new Date(timestamp).toISOString()).toBe(timestamp);
+  });
+});
+
+describe('importFromJson', () => {
+  it('roundtrips a plant through export and import', () => {
+    const plants = [makePlant()];
+    const json = buildExportJson(plants);
+    const imported = importFromJson(json);
+
+    expect(imported).toHaveLength(1);
+    expect(imported[0].name).toBe('Tomaten');
+    expect(imported[0].activities).toHaveLength(1);
+  });
+
+  it('throws on invalid JSON syntax', () => {
+    expect(() => importFromJson('not valid json {')).toThrow();
+  });
+
+  it('throws when version field is missing', () => {
+    const bad = JSON.stringify({ timestamp: new Date().toISOString(), plants: [] });
+    expect(() => importFromJson(bad)).toThrow(/Invalid import format/);
+  });
+
+  it('throws when version is wrong', () => {
+    const bad = JSON.stringify({
+      version: '2.0.0',
+      timestamp: new Date().toISOString(),
+      plants: [],
+    });
+    expect(() => importFromJson(bad)).toThrow(/Invalid import format/);
+  });
+
+  it('throws when plants array contains invalid entry', () => {
+    const bad = JSON.stringify({
+      version: '1.0.0',
+      timestamp: new Date().toISOString(),
+      plants: [{ id: 'x', name: '' }],
+    });
+    expect(() => importFromJson(bad)).toThrow(/Invalid import format/);
+  });
+
+  it('accepts optional location and category fields', () => {
+    const plant = makePlant({ location: 'shade', category: 'flower' });
+    const json = buildExportJson([plant]);
+    const [imported] = importFromJson(json);
+    expect(imported.location).toBe('shade');
+    expect(imported.category).toBe('flower');
+  });
+});

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -63,6 +63,13 @@ function TabsNavigator() {
           }}
         />
         <Tabs.Screen
+          name="templates"
+          options={{
+            title: isDe ? 'Vorlagen' : 'Templates',
+            tabBarIcon: ({ color }) => <TabBarIcon emoji="📄" color={color} />,
+          }}
+        />
+        <Tabs.Screen
           name="settings"
           options={{
             title: isDe ? 'Einstellungen' : 'Settings',

--- a/app/templates.tsx
+++ b/app/templates.tsx
@@ -1,0 +1,2 @@
+import { TemplateScreen } from '../src/screens/TemplateScreen';
+export default TemplateScreen;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -97,6 +97,7 @@ module.exports = [
         localStorage: 'readonly',
         navigator: 'readonly',
         alert: 'readonly',
+        Blob: 'readonly',
         MediaQueryList: 'readonly',
         MediaQueryListEvent: 'readonly',
         __DEV__: 'readonly',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,10 @@ const globals = {
   fetch: 'readonly',
   Buffer: 'readonly',
   URL: 'readonly',
+  Blob: 'readonly',
+  FileReader: 'readonly',
+  document: 'readonly',
+  alert: 'readonly',
 };
 
 /** @type {import('eslint').Linter.Config[]} */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pflanzkalender",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pflanzkalender",
-      "version": "1.3.2",
+      "version": "1.4.0",
       "dependencies": {
         "@react-native-async-storage/async-storage": "^2.2.0",
         "expo": "~54.0.12",

--- a/src/constants/communityTemplates.ts
+++ b/src/constants/communityTemplates.ts
@@ -1,0 +1,255 @@
+import { Plant } from '../types';
+
+type TemplatePlant = Omit<Plant, 'id' | 'createdAt' | 'updatedAt'>;
+
+export interface CommunityTemplate {
+  id: string;
+  name: { de: string; en: string };
+  description: { de: string; en: string };
+  icon: string;
+  plants: TemplatePlant[];
+}
+
+const act = (type: string, start: number, end: number, color: string, label: string) => ({
+  id: `${type}-${start}-${end}`,
+  type,
+  startMonth: start,
+  endMonth: end,
+  color,
+  label,
+});
+
+export const COMMUNITY_TEMPLATES: CommunityTemplate[] = [
+  {
+    id: 'balkon-starter',
+    name: { de: 'Balkon-Garten Starter', en: 'Balcony Garden Starter' },
+    description: {
+      de: '5 Pflanzen perfekt für Balkon und Terrasse',
+      en: '5 plants perfect for balcony and patio',
+    },
+    icon: '🌿',
+    plants: [
+      {
+        name: 'Tomaten',
+        isDefault: false,
+        userId: null,
+        notes: 'Beliebtes Gemüse für Balkon und Garten',
+        location: 'sun',
+        category: 'vegetable',
+        activities: [
+          act('sow', 3, 5, '#8B4513', 'Aussäen'),
+          act('plant', 9, 9, '#228B22', 'Pflanzen'),
+          act('fertilize', 11, 17, '#FFD700', 'Düngen'),
+          act('harvest', 13, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Basilikum',
+        isDefault: false,
+        userId: null,
+        notes: 'Küchenkraut, liebt Wärme',
+        location: 'sun',
+        category: 'vegetable',
+        activities: [
+          act('sow', 5, 9, '#8B4513', 'Aussäen'),
+          act('harvest', 9, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Paprika',
+        isDefault: false,
+        userId: null,
+        notes: 'Wärmeliebendes Gemüse',
+        location: 'sun',
+        category: 'vegetable',
+        activities: [
+          act('sow', 3, 5, '#8B4513', 'Aussäen'),
+          act('plant', 9, 11, '#228B22', 'Pflanzen'),
+          act('harvest', 15, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Erdbeeren',
+        isDefault: false,
+        userId: null,
+        notes: 'Mehrjährige Pflanze, gut für Töpfe',
+        location: 'partial-shade',
+        category: 'vegetable',
+        activities: [
+          act('plant', 15, 17, '#228B22', 'Pflanzen'),
+          act('harvest', 9, 13, '#DC143C', 'Ernten'),
+          act('fertilize', 5, 7, '#FFD700', 'Düngen'),
+        ],
+      },
+      {
+        name: 'Schnittlauch',
+        isDefault: false,
+        userId: null,
+        notes: 'Mehrjähriges Küchenkraut',
+        location: 'partial-shade',
+        category: 'vegetable',
+        activities: [
+          act('sow', 5, 9, '#8B4513', 'Aussäen'),
+          act('harvest', 7, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'gemuesegarten-anfaenger',
+    name: { de: 'Gemüsegarten Anfänger', en: 'Vegetable Garden Beginner' },
+    description: {
+      de: '6 einfache Gemüsepflanzen für Einsteiger',
+      en: '6 easy vegetables for beginners',
+    },
+    icon: '🥕',
+    plants: [
+      {
+        name: 'Salat',
+        isDefault: false,
+        userId: null,
+        notes: 'Schnell wachsend, wenig Pflege',
+        location: 'partial-shade',
+        category: 'vegetable',
+        activities: [
+          act('sow', 5, 15, '#8B4513', 'Aussäen'),
+          act('harvest', 9, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Karotten',
+        isDefault: false,
+        userId: null,
+        notes: 'Wurzelgemüse, im Topf oder Beet',
+        location: 'sun',
+        category: 'vegetable',
+        activities: [
+          act('sow', 5, 13, '#8B4513', 'Aussäen'),
+          act('harvest', 13, 21, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Radieschen',
+        isDefault: false,
+        userId: null,
+        notes: 'Sehr schnell, ideal für Einsteiger',
+        location: 'sun',
+        category: 'vegetable',
+        activities: [
+          act('sow', 5, 17, '#8B4513', 'Aussäen'),
+          act('harvest', 7, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Zucchini',
+        isDefault: false,
+        userId: null,
+        notes: 'Ertragreiche Pflanze',
+        location: 'sun',
+        category: 'vegetable',
+        activities: [
+          act('sow', 7, 9, '#8B4513', 'Aussäen'),
+          act('plant', 9, 11, '#228B22', 'Pflanzen'),
+          act('harvest', 11, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Bohnen',
+        isDefault: false,
+        userId: null,
+        notes: 'Buschbohnen oder Stangenbohnen',
+        location: 'sun',
+        category: 'vegetable',
+        activities: [
+          act('sow', 9, 13, '#8B4513', 'Aussäen'),
+          act('harvest', 13, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Gurken',
+        isDefault: false,
+        userId: null,
+        notes: 'Erfrischend, viel Ertrag',
+        location: 'sun',
+        category: 'vegetable',
+        activities: [
+          act('sow', 7, 9, '#8B4513', 'Aussäen'),
+          act('plant', 9, 11, '#228B22', 'Pflanzen'),
+          act('harvest', 11, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+    ],
+  },
+  {
+    id: 'kraeutergarten',
+    name: { de: 'Kräutergarten', en: 'Herb Garden' },
+    description: {
+      de: '5 beliebte Küchenkräuter',
+      en: '5 popular kitchen herbs',
+    },
+    icon: '🌱',
+    plants: [
+      {
+        name: 'Petersilie',
+        isDefault: false,
+        userId: null,
+        notes: 'Zweijähriges Küchenkraut',
+        location: 'partial-shade',
+        category: 'vegetable',
+        activities: [
+          act('sow', 3, 9, '#8B4513', 'Aussäen'),
+          act('harvest', 7, 23, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Schnittlauch',
+        isDefault: false,
+        userId: null,
+        notes: 'Mehrjährig, sehr robust',
+        location: 'partial-shade',
+        category: 'vegetable',
+        activities: [
+          act('sow', 5, 9, '#8B4513', 'Aussäen'),
+          act('harvest', 7, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Thymian',
+        isDefault: false,
+        userId: null,
+        notes: 'Mediterrane Staude, sehr robust',
+        location: 'sun',
+        category: 'vegetable',
+        activities: [
+          act('sow', 5, 7, '#8B4513', 'Aussäen'),
+          act('harvest', 9, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Minze',
+        isDefault: false,
+        userId: null,
+        notes: 'Sehr ausdauernd, besser im Topf halten',
+        location: 'partial-shade',
+        category: 'vegetable',
+        activities: [
+          act('plant', 7, 11, '#228B22', 'Pflanzen'),
+          act('harvest', 9, 19, '#DC143C', 'Ernten'),
+        ],
+      },
+      {
+        name: 'Rosmarin',
+        isDefault: false,
+        userId: null,
+        notes: 'Immergrüne mediterrane Pflanze',
+        location: 'sun',
+        category: 'vegetable',
+        activities: [
+          act('plant', 7, 9, '#228B22', 'Pflanzen'),
+          act('harvest', 3, 23, '#DC143C', 'Ernten'),
+          act('protect', 21, 23, '#9370DB', 'Winterschutz'),
+        ],
+      },
+    ],
+  },
+];

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -128,6 +128,22 @@ const de: Translations = {
   'activity.type.harvest': 'Ernten',
   'activity.type.protect': 'Winterschutz',
   'activity.type.mulch': 'Mulchen',
+
+  // Template Screen
+  'template.title': 'Vorlagen',
+  'template.tab': 'Vorlagen',
+  'template.tabTemplates': 'Vorlagen',
+  'template.tabExport': 'Exportieren',
+  'template.tabImport': 'Importieren',
+  'template.community': 'COMMUNITY VORLAGEN',
+  'template.exportSection': 'EXPORTIEREN',
+  'template.importSection': 'IMPORTIEREN',
+  'template.importBtn': 'Importieren',
+  'template.exportHint': 'Exportiere alle deine Pflanzen als JSON-Datei und sichere deine Daten.',
+  'template.importHint':
+    'JSON-Daten einfügen oder eine Datei auswählen, um Pflanzen zu importieren.',
+  'template.chooseFile': 'Datei auswählen',
+  'template.pasteJson': 'JSON hier einfügen...',
 };
 
 export default de;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -127,6 +127,21 @@ const en: Translations = {
   'activity.type.harvest': 'Harvest',
   'activity.type.protect': 'Winter protection',
   'activity.type.mulch': 'Mulch',
+
+  // Template Screen
+  'template.title': 'Templates',
+  'template.tab': 'Templates',
+  'template.tabTemplates': 'Templates',
+  'template.tabExport': 'Export',
+  'template.tabImport': 'Import',
+  'template.community': 'COMMUNITY TEMPLATES',
+  'template.exportSection': 'EXPORT',
+  'template.importSection': 'IMPORT',
+  'template.importBtn': 'Import',
+  'template.exportHint': 'Export all your plants as a JSON file to back up your data.',
+  'template.importHint': 'Paste JSON data or choose a file to import plants.',
+  'template.chooseFile': 'Choose File',
+  'template.pasteJson': 'Paste JSON here...',
 };
 
 export default en;

--- a/src/screens/TemplateScreen.tsx
+++ b/src/screens/TemplateScreen.tsx
@@ -1,0 +1,392 @@
+import React, { useState } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  TouchableOpacity,
+  TextInput,
+  Alert,
+  StyleSheet,
+  Platform,
+} from 'react-native';
+import { useTheme } from '../hooks/useTheme';
+import { useLanguage } from '../contexts/LanguageContext';
+import { usePlants } from '../contexts/PlantContext';
+import { COMMUNITY_TEMPLATES } from '../constants/communityTemplates';
+import { sharePlants, importFromJson } from '../services/templateService';
+import { Plant } from '../types';
+
+type Section = 'templates' | 'export' | 'import';
+
+export const TemplateScreen: React.FC = () => {
+  const { theme } = useTheme();
+  const { language, t } = useLanguage();
+  const { plants, addPlant } = usePlants();
+  const isDe = language === 'de';
+
+  const [activeSection, setActiveSection] = useState<Section>('templates');
+  const [importText, setImportText] = useState('');
+  const [importing, setImporting] = useState(false);
+  const [exporting, setExporting] = useState(false);
+
+  const styles = makeStyles();
+
+  const handleImportTemplate = (templateId: string) => {
+    const template = COMMUNITY_TEMPLATES.find((t) => t.id === templateId);
+    if (!template) return;
+
+    template.plants.forEach((plant) => {
+      addPlant(plant);
+    });
+
+    const name = isDe ? template.name.de : template.name.en;
+    Alert.alert(
+      isDe ? 'Importiert!' : 'Imported!',
+      isDe
+        ? `${template.plants.length} Pflanzen aus "${name}" wurden hinzugefügt.`
+        : `${template.plants.length} plants from "${name}" have been added.`
+    );
+  };
+
+  const handleExport = async () => {
+    if (plants.length === 0) {
+      Alert.alert(
+        isDe ? 'Keine Pflanzen' : 'No plants',
+        isDe
+          ? 'Es sind keine Pflanzen zum Exportieren vorhanden.'
+          : 'There are no plants to export.'
+      );
+      return;
+    }
+    setExporting(true);
+    try {
+      await sharePlants(plants);
+      if (Platform.OS !== 'web') {
+        Alert.alert(
+          isDe ? 'Erfolg' : 'Success',
+          isDe ? 'Export erfolgreich!' : 'Export successful!'
+        );
+      }
+    } catch {
+      Alert.alert(isDe ? 'Fehler' : 'Error', isDe ? 'Export fehlgeschlagen.' : 'Export failed.');
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const handleImportJson = async () => {
+    if (!importText.trim()) {
+      Alert.alert(
+        isDe ? 'Hinweis' : 'Note',
+        isDe ? 'Bitte JSON-Daten einfügen.' : 'Please paste JSON data.'
+      );
+      return;
+    }
+    setImporting(true);
+    try {
+      const imported: Plant[] = importFromJson(importText.trim());
+      imported.forEach(({ id: _id, createdAt: _c, updatedAt: _u, ...plant }) => {
+        addPlant(plant);
+      });
+      setImportText('');
+      Alert.alert(
+        isDe ? 'Erfolg' : 'Success',
+        isDe
+          ? `${imported.length} Pflanze(n) wurden importiert.`
+          : `${imported.length} plant(s) have been imported.`
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      Alert.alert(isDe ? 'Fehler' : 'Error', msg);
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const handleChooseFile = () => {
+    if (Platform.OS !== 'web') return;
+    // platform-safe: document only available in web context
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.json,application/json';
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (evt) => {
+        const text = evt.target?.result;
+        if (typeof text === 'string') setImportText(text);
+      };
+      reader.readAsText(file);
+    };
+    input.click();
+  };
+
+  const sectionLabel = (section: Section): string => {
+    if (section === 'templates') return isDe ? 'Vorlagen' : 'Templates';
+    if (section === 'export') return isDe ? 'Exportieren' : 'Export';
+    return isDe ? 'Importieren' : 'Import';
+  };
+
+  return (
+    <ScrollView style={[styles.container, { backgroundColor: theme.background }]}>
+      <Text style={[styles.title, { color: theme.text }]}>{String(t('template.title'))}</Text>
+
+      {/* Section switcher */}
+      <View style={styles.tabRow}>
+        {(['templates', 'export', 'import'] as Section[]).map((section) => (
+          <TouchableOpacity
+            key={section}
+            style={[
+              styles.tabBtn,
+              { borderColor: theme.border },
+              activeSection === section && { backgroundColor: theme.primary },
+            ]}
+            onPress={() => setActiveSection(section)}
+          >
+            <Text
+              style={[
+                styles.tabBtnText,
+                { color: activeSection === section ? '#fff' : theme.textSecondary },
+              ]}
+            >
+              {sectionLabel(section)}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {/* Community Templates */}
+      {activeSection === 'templates' && (
+        <View style={styles.section}>
+          <Text style={[styles.sectionHeader, { color: theme.textSecondary }]}>
+            {String(t('template.community'))}
+          </Text>
+          {COMMUNITY_TEMPLATES.map((tmpl) => (
+            <View
+              key={tmpl.id}
+              style={[styles.card, { backgroundColor: theme.surface, borderColor: theme.border }]}
+            >
+              <View style={styles.cardHeader}>
+                <Text style={styles.cardIcon}>{tmpl.icon}</Text>
+                <View style={styles.cardTitleBlock}>
+                  <Text style={[styles.cardTitle, { color: theme.text }]}>
+                    {isDe ? tmpl.name.de : tmpl.name.en}
+                  </Text>
+                  <Text style={[styles.cardDesc, { color: theme.textSecondary }]}>
+                    {isDe ? tmpl.description.de : tmpl.description.en}
+                  </Text>
+                </View>
+              </View>
+              <Text style={[styles.cardPlants, { color: theme.textSecondary }]}>
+                {tmpl.plants.map((p) => p.name).join(' · ')}
+              </Text>
+              <TouchableOpacity
+                style={[styles.importBtn, { backgroundColor: theme.primary }]}
+                onPress={() => handleImportTemplate(tmpl.id)}
+              >
+                <Text style={styles.importBtnText}>{String(t('template.importBtn'))}</Text>
+              </TouchableOpacity>
+            </View>
+          ))}
+        </View>
+      )}
+
+      {/* Export */}
+      {activeSection === 'export' && (
+        <View style={styles.section}>
+          <Text style={[styles.sectionHeader, { color: theme.textSecondary }]}>
+            {String(t('template.exportSection'))}
+          </Text>
+          <Text style={[styles.hint, { color: theme.textSecondary }]}>
+            {String(t('template.exportHint'))}
+          </Text>
+          <TouchableOpacity
+            style={[
+              styles.actionBtn,
+              { backgroundColor: theme.primary, opacity: exporting ? 0.6 : 1 },
+            ]}
+            onPress={handleExport}
+            disabled={exporting}
+          >
+            <Text style={styles.actionBtnText}>
+              {`📤 ${isDe ? 'Alle' : 'All'} ${plants.length} ${isDe ? 'Pflanzen exportieren' : 'plants export'}`}
+            </Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      {/* Import */}
+      {activeSection === 'import' && (
+        <View style={styles.section}>
+          <Text style={[styles.sectionHeader, { color: theme.textSecondary }]}>
+            {String(t('template.importSection'))}
+          </Text>
+          <Text style={[styles.hint, { color: theme.textSecondary }]}>
+            {String(t('template.importHint'))}
+          </Text>
+
+          {Platform.OS === 'web' && (
+            <TouchableOpacity
+              style={[styles.fileBtn, { borderColor: theme.border }]}
+              onPress={handleChooseFile}
+            >
+              <Text style={[styles.fileBtnText, { color: theme.text }]}>
+                {String(t('template.chooseFile'))}
+              </Text>
+            </TouchableOpacity>
+          )}
+
+          <TextInput
+            style={[
+              styles.jsonInput,
+              { backgroundColor: theme.surface, color: theme.text, borderColor: theme.border },
+            ]}
+            multiline
+            numberOfLines={8}
+            placeholder={String(t('template.pasteJson'))}
+            placeholderTextColor={theme.textSecondary}
+            value={importText}
+            onChangeText={setImportText}
+            textAlignVertical="top"
+          />
+
+          <TouchableOpacity
+            style={[
+              styles.actionBtn,
+              { backgroundColor: theme.primary, opacity: importing ? 0.6 : 1 },
+            ]}
+            onPress={handleImportJson}
+            disabled={importing}
+          >
+            <Text style={styles.actionBtnText}>{`📥 ${isDe ? 'Importieren' : 'Import'}`}</Text>
+          </TouchableOpacity>
+        </View>
+      )}
+
+      <View style={styles.spacer} />
+    </ScrollView>
+  );
+};
+
+const makeStyles = () =>
+  StyleSheet.create({
+    container: {
+      flex: 1,
+    },
+    title: {
+      fontSize: 22,
+      fontWeight: 'bold',
+      padding: 16,
+      paddingBottom: 8,
+    },
+    tabRow: {
+      flexDirection: 'row',
+      marginHorizontal: 16,
+      marginBottom: 12,
+      gap: 8,
+    },
+    tabBtn: {
+      flex: 1,
+      paddingVertical: 8,
+      paddingHorizontal: 4,
+      borderRadius: 8,
+      borderWidth: 1,
+      alignItems: 'center',
+    },
+    tabBtnText: {
+      fontSize: 13,
+      fontWeight: '600',
+    },
+    section: {
+      paddingHorizontal: 16,
+    },
+    sectionHeader: {
+      fontSize: 11,
+      fontWeight: '700',
+      letterSpacing: 0.8,
+      marginBottom: 12,
+      textTransform: 'uppercase',
+    },
+    card: {
+      borderRadius: 12,
+      borderWidth: 1,
+      padding: 14,
+      marginBottom: 12,
+    },
+    cardHeader: {
+      flexDirection: 'row',
+      alignItems: 'flex-start',
+      marginBottom: 8,
+    },
+    cardIcon: {
+      fontSize: 28,
+      marginRight: 12,
+      marginTop: 2,
+    },
+    cardTitleBlock: {
+      flex: 1,
+    },
+    cardTitle: {
+      fontSize: 16,
+      fontWeight: '700',
+      marginBottom: 2,
+    },
+    cardDesc: {
+      fontSize: 13,
+    },
+    cardPlants: {
+      fontSize: 12,
+      marginBottom: 12,
+    },
+    importBtn: {
+      borderRadius: 8,
+      paddingVertical: 10,
+      alignItems: 'center',
+    },
+    importBtnText: {
+      color: '#fff',
+      fontWeight: '600',
+      fontSize: 14,
+    },
+    hint: {
+      fontSize: 14,
+      marginBottom: 16,
+      lineHeight: 20,
+    },
+    actionBtn: {
+      borderRadius: 10,
+      paddingVertical: 14,
+      alignItems: 'center',
+      marginTop: 4,
+    },
+    actionBtnText: {
+      color: '#fff',
+      fontWeight: '700',
+      fontSize: 15,
+    },
+    fileBtn: {
+      borderRadius: 8,
+      borderWidth: 1,
+      paddingVertical: 10,
+      paddingHorizontal: 16,
+      alignItems: 'center',
+      marginBottom: 12,
+    },
+    fileBtnText: {
+      fontWeight: '600',
+      fontSize: 14,
+    },
+    jsonInput: {
+      borderRadius: 8,
+      borderWidth: 1,
+      padding: 12,
+      fontSize: 13,
+      minHeight: 140,
+      marginBottom: 12,
+      fontFamily: 'monospace',
+    },
+    spacer: {
+      height: 40,
+    },
+  });

--- a/src/screens/TemplateScreen.tsx
+++ b/src/screens/TemplateScreen.tsx
@@ -105,7 +105,8 @@ export const TemplateScreen: React.FC = () => {
 
   const handleChooseFile = () => {
     if (Platform.OS !== 'web') return;
-    // platform-safe: document only available in web context
+    // platform-safe: document can be undefined in SSR/test even when Platform.OS === 'web'
+    if (typeof document === 'undefined') return;
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = '.json,application/json';

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -1,6 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { Plant } from '../types';
-import { Share } from 'react-native';
+import { Share, Platform } from 'react-native';
 import { PlantSchema, ImportDataSchema } from '../schemas/plant';
 
 const STORAGE_KEYS = {
@@ -92,19 +92,24 @@ export const storageService = {
       };
 
       const jsonString = JSON.stringify(exportData, null, 2);
-      const fileName = `Pflanzkalender_Export_${new Date().toISOString().split('T')[0]}.json`;
+      const fileName = `pflanzkalender-export.json`;
 
-      // For React Native, use Share API
-      try {
+      if (Platform.OS === 'web') {
+        const blob = new Blob([jsonString], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = fileName;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        // Revoke asynchronously so the browser has time to start the download
+        setTimeout(() => URL.revokeObjectURL(url), 100);
+      } else {
         await Share.share({
           message: jsonString,
           title: fileName,
-          url: undefined,
         });
-      } catch (shareError) {
-        console.error('Error sharing file:', shareError);
-        // Fallback: Copy to clipboard
-        alert('Export data ready. Please copy the data manually.');
       }
     } catch (error) {
       console.error('Error exporting plants:', error);

--- a/src/services/storage.ts
+++ b/src/services/storage.ts
@@ -94,7 +94,8 @@ export const storageService = {
       const jsonString = JSON.stringify(exportData, null, 2);
       const fileName = `pflanzkalender-export.json`;
 
-      if (Platform.OS === 'web') {
+      // platform-safe: document can be undefined in SSR/test even when Platform.OS === 'web'
+      if (Platform.OS === 'web' && typeof document !== 'undefined') {
         const blob = new Blob([jsonString], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -1,0 +1,59 @@
+import { Platform, Share } from 'react-native';
+import { Plant } from '../types';
+import { ImportDataSchema } from '../schemas/plant';
+
+export interface ExportData {
+  version: '1.0.0';
+  timestamp: string;
+  plants: Plant[];
+}
+
+export function buildExportJson(plants: Plant[]): string {
+  const data: ExportData = {
+    version: '1.0.0',
+    timestamp: new Date().toISOString(),
+    plants,
+  };
+  return JSON.stringify(data, null, 2);
+}
+
+export function triggerWebDownload(jsonString: string, filename: string): void {
+  if (Platform.OS !== 'web') return;
+  // platform-safe: document only available in web context
+  const blob = new Blob([jsonString], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export async function sharePlants(plants: Plant[]): Promise<void> {
+  const jsonString = buildExportJson(plants);
+  const filename = `Pflanzkalender_Export_${new Date().toISOString().split('T')[0]}.json`;
+
+  if (Platform.OS === 'web') {
+    triggerWebDownload(jsonString, filename);
+    return;
+  }
+
+  await Share.share({
+    message: jsonString,
+    title: filename,
+  });
+}
+
+export function importFromJson(jsonString: string): Plant[] {
+  const raw = JSON.parse(jsonString);
+  const result = ImportDataSchema.safeParse(raw);
+  if (!result.success) {
+    const details = result.error.issues
+      .map((i) => `${i.path.join('.') || 'root'}: ${i.message}`)
+      .join('; ');
+    throw new Error(`Invalid import format: ${details}`);
+  }
+  return result.data.plants as Plant[];
+}

--- a/src/services/templateService.ts
+++ b/src/services/templateService.ts
@@ -19,7 +19,8 @@ export function buildExportJson(plants: Plant[]): string {
 
 export function triggerWebDownload(jsonString: string, filename: string): void {
   if (Platform.OS !== 'web') return;
-  // platform-safe: document only available in web context
+  // platform-safe: document can be undefined in SSR/test even when Platform.OS === 'web'
+  if (typeof document === 'undefined') return;
   const blob = new Blob([jsonString], { type: 'application/json' });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
@@ -28,7 +29,8 @@ export function triggerWebDownload(jsonString: string, filename: string): void {
   document.body.appendChild(a);
   a.click();
   document.body.removeChild(a);
-  URL.revokeObjectURL(url);
+  // Revoke asynchronously so the browser has time to start the download
+  setTimeout(() => URL.revokeObjectURL(url), 100);
 }
 
 export async function sharePlants(plants: Plant[]): Promise<void> {


### PR DESCRIPTION
## Ziel

Bringt **alle Commits aus `testing`** nach `main`. Die beiden Branches waren divergiert: `main` hatte PR #148/#149 (Issue #123 + #87), `testing` hatte PR #146/#147 (Issue #88 + #8), die noch nicht in main waren.

## Enthaltene testing-Commits

| Commit | Inhalt |
| ------ | ------ |
| `ad4c9fb` (PR #147) | **Issue #8 – Template-System:** `TemplateScreen` (3 Sections), 3 Community-Templates (`communityTemplates.ts`), `templateService.ts` (Web-Download + Share), Route `app/templates.tsx` |
| `f9e9e1b` (PR #146) | **Issue #88 – Export-Fix:** Blob-Download auf Web für Daten-Export via `<a>`-Element |

## Konflikt-Auflösung

- **`src/i18n/de.ts` + `en.ts`:** beide Key-Sätze behalten – `settings.import*` (aus #149) **und** `template.*` (aus #8). Keine doppelten Keys.
- **`CLAUDE.md`:** Projektgedächtnis auf den zusammengeführten Stand aktualisiert (Status, Projektstruktur, offene Issues, Merge-Tabelle).

main behält seine #148/#149-Features (`climateRecommendations.ts`, `storageError.ts`, Import-UI im `SettingsModal`), die testing-Features werden ergänzt.

> Hinweis: Nach dem Merge existieren zwei Import-Pfade – die Import-UI im `SettingsModal` (#149) und der `TemplateScreen` (#8). Funktional unabhängig; eine spätere Konsolidierung kann sinnvoll sein.

## Validierung

- ✅ **364 Tests grün** (27 Suites)
- ✅ Versions-Konsistenz: package.json / app.json = 1.4.0
- ✅ Keine Konfliktmarker, keine doppelten i18n-Keys

https://claude.ai/code/session_01VwPeEs9xnN2o4WmHZhzHLW

---
_Generated by [Claude Code](https://claude.ai/code/session_01VwPeEs9xnN2o4WmHZhzHLW)_