### PR TITLE
docs(CLAUDE.md): Memory nach PR #157 Merge aktualisieren

### DIFF
--- a/.github/workflows/standards-audit.yml
+++ b/.github/workflows/standards-audit.yml
@@ -1,0 +1,38 @@
+name: Standards Audit
+
+# Konsumiert die zentralen Reusable Workflows aus project-templates
+# (S540d/project-templates#7 – Cross-Project-Standardisierung).
+# Läuft bei:
+#   - PRs (Audits gaten Code-Änderungen)
+#   - weekly-self-audit Dispatch (von project-templates/weekly-audit.yml, Mo 08:00)
+#   - manuell (workflow_dispatch)
+#
+# Alle uses-Referenzen sind auf @v1 gepinnt (nie @main – S540d/project-templates#7, Punkt 1).
+
+on:
+  pull_request:
+    branches: [main, testing]
+  repository_dispatch:
+    types: [weekly-self-audit]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  security-scan:
+    uses: S540d/project-templates/.github/workflows/reusable-security-scan.yml@v1
+    with:
+      fail_on_findings: true
+
+  gitignore-audit:
+    uses: S540d/project-templates/.github/workflows/reusable-gitignore-audit.yml@v1
+    with:
+      fail_on_missing: true
+
+  # Rein informativ: der Audit-Step im Reusable Workflow ist intern non-blocking
+  # (läuft auch bei Abweichungen grün durch). Ein job-level continue-on-error ist
+  # auf uses:-Jobs nicht erlaubt – die Non-Blocking-Semantik muss daher im Template
+  # bleiben; security-scan und gitignore-audit (fail_on_*: true) gaten den Merge.
+  dev-standards-audit:
+    uses: S540d/project-templates/.github/workflows/reusable-dev-standards-audit.yml@v1

--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,7 @@ gradlew.bat
 settings.gradle
 .gradle/
 local.properties
+
+# Security – Pflicht-Einträge (Issue #7 / reusable-gitignore-audit)
+.env.local
+credentials.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Deploy: GitHub Pages via `gh-pages` unter `/Pflanzkalender/`
 
 ## Aktuelle Version: 1.4.0 (main)
 
-**Stand 2026-05-31:** main = v1.4.0 (versionCode 5). PR #151 gemergt – `testing`-Commits (Issue #8 Template-System + #88 Export-Fix) sind jetzt in main. main `833a7f3`.
+**Stand 2026-06-03:** main = v1.4.0 (versionCode 5). PR #157 gemergt – CI Standards Audit Listener (project-templates#7) in main. main `eb14beb`.
 
 - **main branch:** v1.4.0 – Issues #123 + #87 (PR #148 / #149) sowie #8 + #88 (PR #147 / #146, via PR #151 nach main) geschlossen
 - **testing branch:** hinter main – sollte auf `origin/main` zurückgesetzt werden (squash-Merge: testing-Commits sind inhaltlich, aber nicht als Hash in main)
@@ -267,7 +267,7 @@ Vollständige Roadmap: https://github.com/S540d/Pflanzkalender/issues/47
 
 ## Offene Issues (Stand 2026-05-31)
 
-**Status: main = v1.4.0, APK/AAB gebaut. PR #151 gemergt (testing-Commits #8 + #88 in main). 364 Tests grün. Offen: #152 (Import-Konsolidierung).**
+**Status: main = v1.4.0, APK/AAB gebaut. PR #157 gemergt (CI Standards Audit). 364 Tests grün. Offen: #152 (Import-Konsolidierung), #155 (PR für #152).**
 
 ### v1.4.0 – abgeschlossen / Play Store
 
@@ -300,10 +300,11 @@ Vollständige Roadmap: https://github.com/S540d/Pflanzkalender/issues/47
 
 ---
 
-## Letzte Merges / Fixes (2026-05-31)
+## Letzte Merges / Fixes (2026-06-03)
 
 | Was                                          | Wann       | Details                                                                                                                                                                                                                                                    |
 | -------------------------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **PR #157:** CI Standards Audit Listener     | 2026-06-03 | ✅ main `eb14beb`: `standards-audit.yml` (reusable-security-scan, reusable-gitignore-audit, reusable-dev-standards-audit @v1); `.gitignore` um `.env.local` + `credentials.json` ergänzt (gitignore-audit Pflichteinträge, project-templates#7) |
 | **PR #151:** testing → main (Merge)          | 2026-05-31 | ✅ main `833a7f3`: alle testing-Commits (#8 Template-System, #88 Export-Fix) nach main; i18n-Konflikte (beide Key-Sätze) + CLAUDE.md aufgelöst; 4 Review-Robustheit-Fixes (document-Guards, URL-Revoke-Defer, Test-Timer); 2 Import-Bugs → #152; 364 Tests |
 | **PR #149:** Issue #87 – Import-UI           | 2026-05-30 | ✅ gemergt: JSON-Import im SettingsModal (Web file picker, Confirm-Dialog, replacePlants), 9 i18n-Keys × 8 Sprachen, ESLint-Globals (Event/HTMLInputElement), 341 Tests                                                                                    |
 | **PR #148:** Issue #123 – Code-Audit         | 2026-05-30 | ✅ gemergt: `climateRecommendations.ts` extrahiert, `withStorageError`-Utility, Navigation-Integrationstests (`tabNavigation.test.tsx`), 338 Tests                                                                                                         |


### PR DESCRIPTION
## Summary

- CLAUDE.md aktualisiert: Stand, Statuszeile und Letzte-Merges-Tabelle nach PR #157 (CI Standards Audit Listener) gemergt auf main `eb14beb`

## Test plan
- [ ] Kein Code geändert, nur Dokumentation

https://claude.ai/code/session_01VdHjWkbU5hjFC919RNU3Nz

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdHjWkbU5hjFC919RNU3Nz)_