### PR TITLE
docs: add PRIVACY_POLICY.md (Issue #34)

### DIFF
--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,14 +1,80 @@
+# Datenschutzerklärung – Pflanzkalender
+
+_Stand: wird beim nächsten Release aktualisiert_
+
+## 1. Verantwortlicher
+
+Sven-Uwe Strohkark  
+E-Mail: DevSven@posteo.de
+
+## 2. Übersicht
+
+Die Pflanzkalender-App dient der Verwaltung von Pflanzplänen. Diese Datenschutzerklärung erläutert den Umgang mit Ihren Daten.
+
+## 3. Datenerhebung
+
+**Wir erheben, speichern oder verarbeiten keine personenbezogenen Daten auf eigenen Servern.**
+
+Die App:
+
+- ✅ Erfordert keine Benutzerkonten oder Anmeldung
+- ✅ Sammelt keine persönlichen Informationen (Name, E-Mail, Telefon, etc.)
+- ✅ Verfolgt nicht Ihren Standort
+- ✅ Verwendet keine Cookies oder Tracking-Technologien
+- ✅ Teilt keine Daten mit Dritten
+- ✅ Enthält keine Werbe- oder Analyse-SDKs
+- ✅ Benötigt für die Kernfunktion keine Internetverbindung
+
+## 4. Lokal gespeicherte Daten
+
+Die App speichert folgende Daten **nur auf Ihrem Gerät** (lokaler Gerätespeicher):
+
+- Anzeigeeinstellungen (Theme, Sprache)
+- Von Ihnen eingegebene Pflanzkalender-Daten
+
+Diese Daten werden niemals an Server übertragen. Alle Daten verbleiben auf Ihrem Gerät und werden beim Deinstallieren der App gelöscht.
+
+## 5. Web-App und GitHub Pages
+
+Die App ist auch als Web-App über GitHub Pages abrufbar. Beim Abruf einer Web-App können durch den Hosting-Anbieter (GitHub, Inc.) technische Zugriffsdaten wie IP-Adressen protokolliert werden. Dies liegt außerhalb unserer Kontrolle; bitte beachten Sie die Datenschutzerklärung von GitHub: https://docs.github.com/de/site-policy/privacy-policies/github-general-privacy-statement
+
+## 6. Datenschutz für Kinder
+
+Diese App erhebt wissentlich keine Daten von Kindern unter 13 Jahren. Es erfolgt unabhängig vom Alter keine Datenerfassung durch uns.
+
+## 7. Änderungen dieser Richtlinie
+
+Wir können diese Datenschutzerklärung gelegentlich aktualisieren. Änderungen werden im Repository mit aktualisiertem Datum veröffentlicht.
+
+## 8. Open Source
+
+Diese App ist Open Source. Den vollständigen Quellcode finden Sie unter:  
+https://github.com/S540d/Pflanzkalender
+
+## 9. Kontakt
+
+Bei Fragen zu dieser Datenschutzerklärung:  
+E-Mail: DevSven@posteo.de  
+GitHub Issues: https://github.com/S540d/Pflanzkalender/issues
+
+---
+
 # Privacy Policy – Pflanzkalender
 
-**Last updated: June 7, 2026**
+_Last updated: updated with each release_
 
-## Overview
+## 1. Controller
 
-Pflanzkalender ("we", "our", or "the app") is a gardening calendar app for managing planting schedules. This Privacy Policy explains how the app handles your data.
+Sven-Uwe Strohkark  
+Email: DevSven@posteo.de
 
-## Data Collection
+## 2. Overview
 
-**We do NOT collect, store, or process any personal data.**
+The Pflanzkalender app is a gardening calendar for managing planting schedules. This Privacy Policy explains how the app handles your data.
+
+## 3. Data Collection
+
+**We do NOT collect, store, or process any personal data on our own servers.**
 
 The app:
 
@@ -20,86 +86,34 @@ The app:
 - ✅ Does NOT contain advertising or analytics SDKs
 - ✅ Does NOT require internet access for core functionality
 
-## Data Stored Locally
+## 4. Data Stored Locally
 
-The app stores the following data **only on your device**:
+The app stores the following data **only on your device** (local device storage):
 
 - Display preferences (theme, language)
 - Any planting data you enter
 
-This data is stored using React Native's AsyncStorage and is never transmitted to any server.
+This data is never transmitted to any server. All data remains on your device and is deleted when you uninstall the app.
 
-## Internet Permissions
+## 5. Web App and GitHub Pages
 
-The app may require internet access only for web deployment (GitHub Pages). No personal data is transmitted.
+The app is also accessible as a web app via GitHub Pages. When loading a web app, the hosting provider (GitHub, Inc.) may log technical access data such as IP addresses. This is outside our control; please refer to GitHub's Privacy Statement: https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement
 
-## Children's Privacy
+## 6. Children's Privacy
 
-This app does not knowingly collect information from children under 13 years of age. No data collection occurs regardless of age.
+This app does not knowingly collect data from children under 13 years of age. No data collection by us occurs regardless of age.
 
-## Changes to This Policy
+## 7. Changes to This Policy
 
-We may update this Privacy Policy from time to time. Any changes will be posted on this page with an updated "Last updated" date.
+We may update this Privacy Policy from time to time. Changes will be published in the repository with an updated date.
 
-## Open Source
+## 8. Open Source
 
-This app is open source. You can review the complete source code at:
+This app is open source. You can review the complete source code at:  
 https://github.com/S540d/Pflanzkalender
 
-## Contact
+## 9. Contact
 
-If you have questions about this Privacy Policy:
-
-- GitHub Issues: https://github.com/S540d/Pflanzkalender/issues
-
----
-
-## Datenschutzerklärung – Pflanzkalender
-
-**Zuletzt aktualisiert: 7. Juni 2026**
-
-## Übersicht
-
-Pflanzkalender ist eine Garten-Kalender-App zur Verwaltung von Pflanzplänen.
-
-## Datenerhebung
-
-**Wir erheben, speichern oder verarbeiten KEINE personenbezogenen Daten.**
-
-Die App:
-
-- ✅ Erfordert KEINE Benutzerkonten oder Anmeldung
-- ✅ Sammelt KEINE persönlichen Informationen (Name, E-Mail, Telefon, etc.)
-- ✅ Verfolgt NICHT Ihren Standort
-- ✅ Verwendet KEINE Cookies oder Tracking-Technologien
-- ✅ Teilt KEINE Daten mit Dritten
-- ✅ Enthält KEINE Werbe- oder Analyse-SDKs
-- ✅ Benötigt für die Kernfunktion KEINE Internetverbindung
-
-## Lokal gespeicherte Daten
-
-Die App speichert folgende Daten **nur auf Ihrem Gerät**:
-
-- Anzeigeeinstellungen (Theme, Sprache)
-- Von Ihnen eingegebene Pflanzkalender-Daten
-
-Alle Daten werden mit React Native's AsyncStorage gespeichert und niemals an einen Server übertragen.
-
-## Datenschutz für Kinder
-
-Diese App sammelt wissentlich keine Daten von Kindern unter 13 Jahren. Es erfolgt unabhängig vom Alter keine Datenerfassung.
-
-## Änderungen dieser Richtlinie
-
-Wir können diese Datenschutzerklärung gelegentlich aktualisieren. Änderungen werden auf dieser Seite mit aktualisiertem Datum veröffentlicht.
-
-## Open Source
-
-Diese App ist Open Source. Den vollständigen Quellcode finden Sie unter:
-https://github.com/S540d/Pflanzkalender
-
-## Kontakt
-
-Bei Fragen zu dieser Datenschutzerklärung:
-
-- GitHub Issues: https://github.com/S540d/Pflanzkalender/issues
+For questions about this Privacy Policy:  
+Email: DevSven@posteo.de  
+GitHub Issues: https://github.com/S540d/Pflanzkalender/issues

--- a/PRIVACY_POLICY.md
+++ b/PRIVACY_POLICY.md
@@ -1,0 +1,105 @@
+# Privacy Policy – Pflanzkalender
+
+**Last updated: June 7, 2026**
+
+## Overview
+
+Pflanzkalender ("we", "our", or "the app") is a gardening calendar app for managing planting schedules. This Privacy Policy explains how the app handles your data.
+
+## Data Collection
+
+**We do NOT collect, store, or process any personal data.**
+
+The app:
+
+- ✅ Does NOT require user accounts or login
+- ✅ Does NOT collect personal information (name, email, phone, etc.)
+- ✅ Does NOT track your location
+- ✅ Does NOT use cookies or tracking technologies
+- ✅ Does NOT share data with third parties
+- ✅ Does NOT contain advertising or analytics SDKs
+- ✅ Does NOT require internet access for core functionality
+
+## Data Stored Locally
+
+The app stores the following data **only on your device**:
+
+- Display preferences (theme, language)
+- Any planting data you enter
+
+This data is stored using React Native's AsyncStorage and is never transmitted to any server.
+
+## Internet Permissions
+
+The app may require internet access only for web deployment (GitHub Pages). No personal data is transmitted.
+
+## Children's Privacy
+
+This app does not knowingly collect information from children under 13 years of age. No data collection occurs regardless of age.
+
+## Changes to This Policy
+
+We may update this Privacy Policy from time to time. Any changes will be posted on this page with an updated "Last updated" date.
+
+## Open Source
+
+This app is open source. You can review the complete source code at:
+https://github.com/S540d/Pflanzkalender
+
+## Contact
+
+If you have questions about this Privacy Policy:
+
+- GitHub Issues: https://github.com/S540d/Pflanzkalender/issues
+
+---
+
+## Datenschutzerklärung – Pflanzkalender
+
+**Zuletzt aktualisiert: 7. Juni 2026**
+
+## Übersicht
+
+Pflanzkalender ist eine Garten-Kalender-App zur Verwaltung von Pflanzplänen.
+
+## Datenerhebung
+
+**Wir erheben, speichern oder verarbeiten KEINE personenbezogenen Daten.**
+
+Die App:
+
+- ✅ Erfordert KEINE Benutzerkonten oder Anmeldung
+- ✅ Sammelt KEINE persönlichen Informationen (Name, E-Mail, Telefon, etc.)
+- ✅ Verfolgt NICHT Ihren Standort
+- ✅ Verwendet KEINE Cookies oder Tracking-Technologien
+- ✅ Teilt KEINE Daten mit Dritten
+- ✅ Enthält KEINE Werbe- oder Analyse-SDKs
+- ✅ Benötigt für die Kernfunktion KEINE Internetverbindung
+
+## Lokal gespeicherte Daten
+
+Die App speichert folgende Daten **nur auf Ihrem Gerät**:
+
+- Anzeigeeinstellungen (Theme, Sprache)
+- Von Ihnen eingegebene Pflanzkalender-Daten
+
+Alle Daten werden mit React Native's AsyncStorage gespeichert und niemals an einen Server übertragen.
+
+## Datenschutz für Kinder
+
+Diese App sammelt wissentlich keine Daten von Kindern unter 13 Jahren. Es erfolgt unabhängig vom Alter keine Datenerfassung.
+
+## Änderungen dieser Richtlinie
+
+Wir können diese Datenschutzerklärung gelegentlich aktualisieren. Änderungen werden auf dieser Seite mit aktualisiertem Datum veröffentlicht.
+
+## Open Source
+
+Diese App ist Open Source. Den vollständigen Quellcode finden Sie unter:
+https://github.com/S540d/Pflanzkalender
+
+## Kontakt
+
+Bei Fragen zu dieser Datenschutzerklärung:
+
+- GitHub Issues: https://github.com/S540d/Pflanzkalender/issues


### PR DESCRIPTION
## Summary

- Adds `PRIVACY_POLICY.md` for this offline-first app (bilingual DE/EN)
- Confirms: no network calls, no personal data collected, local AsyncStorage only

## Why

Play Store compliance — all published apps require a Privacy Policy. Part of Phase 3 standardization (#34).

## Test plan
- [x] File created and committed (Prettier applied)
- [ ] CI green
- [ ] review-gate green

🤖 Generated with [Claude Code](https://claude.com/claude-code)