### PR TITLE
release: v1.5.1 (Review-Modell v2 + CI-Wartung)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.5.1] - 2026-06-13
+
+### Geändert
+
+- CI/Review-Workflow auf Review-Modell v2 umgestellt: kostenloses Merge-Gate (GitHub-Mergeability) statt API-gebundenem Gate; KI-Review nur noch on-demand via Label (#178)
+- `pr-review.yml` Berechtigungen korrigiert (`contents: read`, Autofix-Job entfernt) und staging-Referenzen entfernt (#175, #177)
+
 ## [1.3.0] - 2026-05-10
 
 ### Hinzugefügt

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Pflanzkalender",
     "slug": "Pflanzkalender",
-    "version": "1.5.0",
+    "version": "1.5.1",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pflanzkalender",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/twa-manifest.template.json
+++ b/twa-manifest.template.json
@@ -21,8 +21,8 @@
     "path": "./android.keystore",
     "alias": "android"
   },
-  "appVersionCode": 5,
-  "appVersionName": "1.5.0",
+  "appVersionCode": 7,
+  "appVersionName": "1.5.1",
   "shortcuts": [],
   "generatorApp": "bubblewrap-cli",
   "generatorVersion": "1.21.1",


### PR DESCRIPTION
## Was
Version-Bump 1.5.0 → 1.5.1 als Vorbereitung für den Release testing → main + neuen TWA-AAB-Build.

## Änderungen in diesem Release (testing → main)
- Review-Modell v2: kostenloses Merge-Gate (GitHub-Mergeability), KI-Review on-demand via Label (#178)
- `pr-review.yml` Permission-/Workflow-Fixes, staging-Referenzen entfernt (#175, #177)
- Version-Bump 1.5.0 → 1.5.1 (app.json, package.json)
- `twa-manifest.json` (gitignored) lokal auf 1.5.1 / versionCode 7 für den AAB-Build

> Hinweis: Reines PWA/TWA-Projekt (`platforms: ["web"]`). Die 6 testing-Commits enthalten keine App-Code-Änderung, nur CI-Wartung. AAB wird nach dem Merge lokal via Bubblewrap gebaut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)