### PR TITLE
release: v1.5.2 (README + Prettier-Cleanup)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ## [Unreleased]
 
+## [1.5.2] - 2026-06-24
+
+### Geändert
+
+- README vereinfacht: kein Setup, kein App-Store-Link, Features aktuell
+- Prettier-Formatierung auf `aufräumen.md` angewendet
+
 ## [1.5.1] - 2026-06-13
 
 ### Geändert

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Pflanzkalender",
     "slug": "Pflanzkalender",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pflanzkalender",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/twa-manifest.template.json
+++ b/twa-manifest.template.json
@@ -21,8 +21,8 @@
     "path": "./android.keystore",
     "alias": "android"
   },
-  "appVersionCode": 7,
-  "appVersionName": "1.5.1",
+  "appVersionCode": 9,
+  "appVersionName": "1.5.2",
   "shortcuts": [],
   "generatorApp": "bubblewrap-cli",
   "generatorVersion": "1.21.1",


### PR DESCRIPTION
## Summary

- Bump `package.json`, `app.json`, `twa-manifest.template.json` to v1.5.2 / versionCode 9
- CHANGELOG aktualisiert (README-Vereinfachung + Prettier-Cleanup)
- Entspricht den Commits seit v1.5.1: README-Vereinfachung (#80) + Prettier `aufräumen.md`

## Test plan

- [ ] Version in package.json, app.json, twa-manifest.template.json stimmen überein (1.5.2)
- [ ] CHANGELOG enthält `[1.5.2]` Eintrag

🤖 Generated with [Claude Code](https://claude.com/claude-code)