### PR TITLE
chore: bump version to 1.6.0 (appVersionCode 13)

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Pflanzkalender",
     "slug": "Pflanzkalender",
-    "version": "1.5.4",
+    "version": "1.6.0",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "light",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pflanzkalender",
-  "version": "1.5.4",
+  "version": "1.6.0",
   "main": "expo-router/entry",
   "scripts": {
     "start": "expo start",

--- a/twa-manifest.template.json
+++ b/twa-manifest.template.json
@@ -21,8 +21,8 @@
     "path": "./android.keystore",
     "alias": "android"
   },
-  "appVersionCode": 11,
-  "appVersionName": "1.5.4",
+  "appVersionCode": 13,
+  "appVersionName": "1.6.0",
   "shortcuts": [],
   "generatorApp": "bubblewrap-cli",
   "generatorVersion": "1.21.1",


### PR DESCRIPTION
## Summary
- Version bump 1.5.4 → 1.6.0
- appVersionCode 11 → 13 (Play Store build counter)
- Synced in package.json, app.json, twa-manifest.template.json

## Test plan
- [ ] CI passes (version consistency check)