### PR TITLE
feat(seo): add SEO basics for GitHub Pages landing page

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://s540d.github.io/Pflanzkalender/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://s540d.github.io/Pflanzkalender/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/scripts/add-pwa-meta-tags.js
+++ b/scripts/add-pwa-meta-tags.js
@@ -7,6 +7,9 @@ const indexPath = path.join(distPath, 'index.html');
 // Determine base URL from environment or defaults
 const isTesting = process.env.TESTING === 'true';
 const baseUrl = isTesting ? '/Pflanzkalender-testing' : '/Pflanzkalender';
+const siteUrl = `https://s540d.github.io${baseUrl}/`;
+const description =
+  'Pflanzkalender: kostenlose PWA für den Gartenkalender – Aussaat, Pflanzung und Pflege für 32 vordefinierte Pflanzen in Halbmonats-Auflösung planen, offline nutzbar, ohne Login.';
 
 if (fs.existsSync(indexPath)) {
   let html = fs.readFileSync(indexPath, 'utf8');
@@ -21,7 +24,44 @@ if (fs.existsSync(indexPath)) {
     {
       tag: 'meta',
       attr: 'name="description"',
-      html: `<meta name="description" content="Plant Calendar – Gartenaktivitäten mit halber Monatsauflösung planen und verwalten">`,
+      html: `<meta name="description" content="${description}">`,
+    },
+    {
+      tag: 'meta',
+      attr: 'name="robots"',
+      // Only the production deployment should be indexed; the testing
+      // deployment would otherwise be crawlable duplicate content.
+      html: `<meta name="robots" content="${isTesting ? 'noindex, nofollow' : 'index, follow'}">`,
+    },
+    {
+      tag: 'link',
+      attr: 'rel="canonical"',
+      html: `<link rel="canonical" href="${siteUrl}">`,
+    },
+    {
+      tag: 'meta',
+      attr: 'property="og:title"',
+      html: `<meta property="og:title" content="Pflanzkalender">`,
+    },
+    {
+      tag: 'meta',
+      attr: 'property="og:description"',
+      html: `<meta property="og:description" content="${description}">`,
+    },
+    {
+      tag: 'meta',
+      attr: 'property="og:type"',
+      html: `<meta property="og:type" content="website">`,
+    },
+    {
+      tag: 'meta',
+      attr: 'property="og:url"',
+      html: `<meta property="og:url" content="${siteUrl}">`,
+    },
+    {
+      tag: 'meta',
+      attr: 'property="og:image"',
+      html: `<meta property="og:image" content="${siteUrl}icon-512.png">`,
     },
     {
       tag: 'meta',


### PR DESCRIPTION
## Summary
- Add `<meta name="description">`, Open Graph tags (`og:title`, `og:description`, `og:type`, `og:url`, `og:image`), `<meta name="robots">`, and `<link rel="canonical">` to the generated `index.html`, injected via `scripts/add-pwa-meta-tags.js` (there is no static `public/index.html` source template — Expo Router generates the page from `app.json`, so this post-export script is the actual place head tags are controlled).
- Testing deployments (`TESTING=true`) get `robots: noindex, nofollow` and testing-specific canonical/OG URLs to avoid duplicate-content indexing — only `https://s540d.github.io/Pflanzkalender/` should be discoverable via search engines.
- Add `public/robots.txt` (allow all, points to sitemap) and `public/sitemap.xml` (single root URL entry). Verified these are automatically copied into `dist/` by `expo export --platform web` (Expo copies the whole `public/` directory to the export root), same as the existing `public/manifest.json` and `public/privacy.html`.

## Test plan
- [x] `npm run lint` — clean
- [x] `npm test` — 384/384 passing
- [x] `npm run build` (full production build script) — succeeds end to end
- [x] Verified generated `dist/index.html` contains all new tags after a clean production build
- [x] Verified `TESTING=true` build produces `noindex, nofollow` + `/Pflanzkalender-testing/` URLs
- [x] Verified re-running `add-pwa-meta-tags.js` on an already-tagged `dist/index.html` adds 0 duplicate tags (idempotent)
- [x] Verified `dist/robots.txt` and `dist/sitemap.xml` are present after `expo export`

Part of S540d/project-templates#95