### PR TITLE
Fix #206: Android 15 Edge-to-Edge (androidbrowserhelper 2.6.2 → 2.7.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,6 +248,18 @@ Das native Android-Projekt (`android/app/build.gradle` mit `compileSdkVersion`/`
 
 Play Console verlangt ab 31.08.2026 `targetSdkVersion 36` (Android 16) für neue Uploads bestehender Apps (Stand Google-Play-Anforderungen, Google gewährt auf Anfrage Fristverlängerung bis 01.11.2026).
 
+### Android 15 Edge-to-Edge / deprecated Status-/Navbar-APIs (Issue #206) – `scripts/patch-twa-edge-to-edge.sh`
+
+Play Console meldet für die TWA die Nutzung unter Android 15 nicht mehr unterstützter APIs (`Window.setStatusBarColor`/`getStatusBarColor`/`setNavigationBarColor`, `LAYOUT_IN_DISPLAY_CUTOUT_MODE_*`). **Kein eigener App-Code** ist betroffen – die Aufrufe stammen aus `androidbrowserhelper:2.6.2`, der von Bubblewrap gepinnten Version. `androidbrowserhelper 2.7.0` (PR GoogleChrome/android-browser-helper#525) ersetzt diese durch `WindowInsetsController`-basierte Edge-to-Edge-Behandlung. Bubblewrap (`@bubblewrap/core` bis 1.24.1) zieht 2.7.x aber **nicht** automatisch als Stable.
+
+Da das generierte `android/`-Projekt gitignored ist, wird der Fix nach jeder Bubblewrap-(Re)Generierung über ein **tracked Skript** re-appliziert – **vor** `./gradlew bundleRelease` ausführen:
+
+```bash
+bash scripts/patch-twa-edge-to-edge.sh
+```
+
+Das Skript ist idempotent und setzt in den generierten Gradle-Dateien: `androidbrowserhelper` → `2.7.2`; `jcenter()` → `mavenCentral()` (jcenter ist EOL und war das einzige Nicht-`google()`-Repo, über das u. a. die Buildscript-Classpath-Artefakte aufgelöst werden – ersatzloses Löschen bricht den Build); `minSdkVersion` → `23` (ABH 2.7.x fordert minSdk 23, Bubblewrap defaultet auf 21 → sonst Manifest-Merge-Fehler).
+
 ### Squash-Merge: Feature-Branches nach Merge löschen
 
 Bleiben Feature-Branches nach einem Squash-Merge im Remote stehen, schlägt jeder spätere Merge oder Rebase mit ihnen mit add/add-Konflikten in den ursprünglich gemergten Dateien fehl – Git erkennt die Inhaltsgleichheit der squash-erzeugten Commits nicht, weil sie neue Hashes haben. **Immer Branch nach Merge löschen.** Falls schon zu spät: nur den Diff `branch..main` als Patch ausschneiden, auf einen frischen Branch von main anwenden, alten Branch wegwerfen (siehe Vorgehen bei PR #75).

--- a/scripts/patch-twa-edge-to-edge.sh
+++ b/scripts/patch-twa-edge-to-edge.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+#
+# patch-twa-edge-to-edge.sh — Issue #206
+#
+# Der Play-Store-Build ist ein von Bubblewrap generiertes TWA-Projekt. Die
+# generierten Gradle-Dateien (build.gradle, app/build.gradle, ...) sind
+# gitignored und werden bei jeder Neugenerierung überschrieben. Sie pinnen
+# androidbrowserhelper auf 2.6.2 – diese Version ruft intern die unter
+# Android 15 nicht mehr unterstützten APIs
+#   Window.setStatusBarColor / getStatusBarColor / setNavigationBarColor
+#   + LAYOUT_IN_DISPLAY_CUTOUT_MODE_*
+# auf. Google Play meldet das als "Nicht mehr unterstützte Edge-to-Edge-APIs".
+#
+# androidbrowserhelper 2.7.0 (PR GoogleChrome/android-browser-helper#525,
+# "limit deprecated apis to android 14") ersetzt diese Aufrufe durch die
+# WindowInsetsController-basierte Edge-to-Edge-Behandlung. Bubblewrap picked
+# diese Version aber (Stand @bubblewrap/core 1.24.1) noch NICHT automatisch
+# als Stable – daher patchen wir den generierten Build hier nachträglich.
+#
+# Dieses Skript nach jeder Bubblewrap-(Re)Generierung ausführen, VOR
+# `./gradlew bundleRelease`. Idempotent – mehrfaches Ausführen ist unschädlich.
+#
+# Verwendung:  bash scripts/patch-twa-edge-to-edge.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP_GRADLE="$ROOT/app/build.gradle"
+ROOT_GRADLE="$ROOT/build.gradle"
+
+# Ziel-Version von androidbrowserhelper (erste Stable mit Android-15-Edge-to-Edge-Fix)
+ABH_TARGET="2.7.2"
+
+if [ ! -f "$APP_GRADLE" ]; then
+  echo "FEHLER: $APP_GRADLE nicht gefunden. Zuerst das TWA-Projekt generieren/bauen." >&2
+  exit 1
+fi
+
+# 1) androidbrowserhelper auf die Edge-to-Edge-fähige Version pinnen
+if grep -q "androidbrowserhelper:androidbrowserhelper:$ABH_TARGET" "$APP_GRADLE"; then
+  echo "androidbrowserhelper bereits auf $ABH_TARGET gepinnt."
+else
+  sed -i '' -E \
+    "s/androidbrowserhelper:androidbrowserhelper:[0-9]+\.[0-9]+\.[0-9]+/androidbrowserhelper:androidbrowserhelper:$ABH_TARGET/" \
+    "$APP_GRADLE"
+  echo "androidbrowserhelper → $ABH_TARGET gepinnt (app/build.gradle)."
+fi
+
+# 2) jcenter() → mavenCentral() ersetzen. jcenter ist read-only/EOL; ABH 2.7.0
+#    hat jcenter aus den eigenen Repos entfernt (PR #546). jcenter NICHT
+#    ersatzlos löschen – es ist im generierten Projekt das einzige Nicht-google()-
+#    Repo, über das u. a. die Buildscript-Classpath-Artefakte (kotlin-stdlib,
+#    commons-io, asm ...) aufgelöst werden. Ohne mavenCentral() schlägt der Build fehl.
+# Nur die Repo-Deklarationen in der Root-build.gradle (buildscript + allprojects)
+# betreffen die Auflösung. app/build.gradle hat bewusst einen leeren
+# repositories{}-Block und erbt die Repos – daher hier nicht behandeln.
+if grep -q "jcenter()" "$ROOT_GRADLE"; then
+  sed -i '' -E 's/([[:space:]]*)jcenter\(\)/\1mavenCentral()/' "$ROOT_GRADLE"
+  echo "jcenter() → mavenCentral() ersetzt in build.gradle."
+elif grep -q "mavenCentral()" "$ROOT_GRADLE"; then
+  echo "mavenCentral() bereits vorhanden (build.gradle)."
+else
+  echo "WARN: weder jcenter() noch mavenCentral() in build.gradle – Repos prüfen." >&2
+fi
+
+# 3) minSdkVersion auf 23 anheben. androidbrowserhelper 2.7.x setzt minSdk 23
+#    voraus (Bubblewrap/twa-manifest defaulten auf 21) – ohne Anhebung schlägt
+#    der Manifest-Merge fehl. API 23 (Android 6.0, 2015) deckt praktisch alle
+#    aktiven Geräte ab.
+if grep -qE "minSdkVersion 2[0-2]\b" "$APP_GRADLE"; then
+  sed -i '' -E "s/minSdkVersion 2[0-2]\b/minSdkVersion 23/" "$APP_GRADLE"
+  echo "minSdkVersion → 23 angehoben (app/build.gradle)."
+else
+  echo "minSdkVersion bereits ≥ 23."
+fi
+
+echo "Fertig. Edge-to-Edge-Patch (Issue #206) angewendet."


### PR DESCRIPTION
Closes #206

## Problem
Google Play meldet die Nutzung unter **Android 15 nicht mehr unterstützter Edge-to-Edge-APIs** (`setStatusBarColor`/`getStatusBarColor`/`setNavigationBarColor`, `LAYOUT_IN_DISPLAY_CUTOUT_MODE_*`).

## Analyse
- **Kein eigener App-Code betroffen.** Diese App ist eine von Bubblewrap generierte **TWA** (`platforms: ["web"]`, kein natives RN-Build). Die Play-Console-Stacktraces (`com.facebook.react.*`) sind Googles generischer, aggregierter Deprecation-Report.
- Tatsächliche Ursache: **`androidbrowserhelper:2.6.2`**, die von Bubblewrap (`@bubblewrap/core` bis 1.24.1) gepinnte Version, ruft die deprecated APIs intern auf.
- **`androidbrowserhelper 2.7.0`** (PR GoogleChrome/android-browser-helper#525, _"limit deprecated apis to android 14"_) ersetzt sie durch `WindowInsetsController`-basiertes Edge-to-Edge. Bubblewrap zieht 2.7.x aber nicht automatisch als Stable.

## Fix
Das generierte `android/`-Projekt ist gitignored. Deshalb re-appliziert ein **tracked, idempotentes Skript** `scripts/patch-twa-edge-to-edge.sh` den Fix nach jeder Bubblewrap-(Re)Generierung, **vor** `./gradlew bundleRelease`:

- `androidbrowserhelper` → **2.7.2**
- `jcenter()` → **mavenCentral()** (jcenter ist EOL und war das einzige Nicht-`google()`-Repo, über das u. a. die Buildscript-Classpath-Artefakte aufgelöst werden – ersatzloses Löschen bricht den Build)
- `minSdkVersion` → **23** (ABH 2.7.x fordert minSdk 23; Bubblewrap defaultet auf 21 → sonst Manifest-Merge-Fehler)

CLAUDE.md um einen Abschnitt zum Fix + Skript-Nutzung ergänzt.

## Verifikation (lokal)
- `./gradlew :app:bundleRelease` → **BUILD SUCCESSFUL** (AAB 3.1 MB, ABH 2.7.2 resolved)
- Skript idempotent (mehrfaches Ausführen unschädlich)
- `npm test` → **384 Tests grün** (30 Suites)

## Nächster Schritt (out of scope dieses PR)
Neuen AAB mit ABH 2.7.2 bauen, `appVersionCode` hochzählen und im Play Store hochladen, damit der Deprecation-Report verschwindet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)