### PR TITLE
TWA-Patch-Skript für targetSdk 36 + Large-Screen-Fix (#210, #202)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -260,6 +260,23 @@ bash scripts/patch-twa-edge-to-edge.sh
 
 Das Skript ist idempotent und setzt in den generierten Gradle-Dateien: `androidbrowserhelper` → `2.7.2`; `jcenter()` → `mavenCentral()` (jcenter ist EOL und war das einzige Nicht-`google()`-Repo, über das u. a. die Buildscript-Classpath-Artefakte aufgelöst werden – ersatzloses Löschen bricht den Build); `minSdkVersion` → `23` (ABH 2.7.x fordert minSdk 23, Bubblewrap defaultet auf 21 → sonst Manifest-Merge-Fehler).
 
+### Play Store API-Level 36 + Large-Screen-Warnung (Issue #210 / #202) – `scripts/patch-twa-target-sdk36.sh`
+
+Zwei weitere Play-Console-Warnungen betreffen ebenfalls nur das generierte, gitignorete `android/`-Projekt (nicht den App-Code):
+
+- **#210:** `targetSdkVersion`/`compileSdkVersion` müssen auf **36** (Android 16) angehoben sein (Play-Store-Pflicht ab 31.08.2026, siehe oben).
+- **#202:** Die Large-Screen-Warnung verlangt `android:resizeableActivity="true"` im generierten `AndroidManifest.xml`. Die Quelle ist bereits korrekt (`twa-manifest.template.json` → `"orientation": "default"`), nur die generierten Artefakte (`app/build.gradle`, `AndroidManifest.xml`) hinken nach einer Bubblewrap-Regenerierung hinterher.
+
+Wie beim Edge-to-Edge-Fix (#206) gibt es dafür ein **tracked Skript**, das nach jeder Bubblewrap-(Re)Generierung – zusätzlich zu `patch-twa-edge-to-edge.sh` – **vor** `./gradlew bundleRelease` läuft:
+
+```bash
+bash scripts/patch-twa-target-sdk36.sh
+```
+
+Das Skript ist idempotent und setzt: `compileSdkVersion`/`targetSdkVersion` → `36` (`app/build.gradle`); `android:resizeableActivity="true"` im `<application>`-Tag (`app/src/main/AndroidManifest.xml`). Ob die installierte Bubblewrap-Version 36 inzwischen selbst als Default setzt, vor jedem Lauf kurz prüfen (`grep compileSdkVersion app/build.gradle`) – das Skript ist dann ein No-op. Falls AGP-/Gradle-Wrapper-Version oder `androidx.browser` für API 36 ebenfalls angehoben werden müssen, ist das (Stand dieses Issues) noch nicht automatisiert und manuell zu prüfen.
+
+**Wichtig:** Beide Issues können nicht durch einen reinen Repo-Commit „gelöst" werden – das Akzeptanzkriterium ist jeweils der tatsächliche Play-Console-Zustand nach einem neuen Upload. Die hier committeten Skripte automatisieren den lokalen Build-Schritt; Bubblewrap-Regenerierung, `gradlew bundleRelease`, Signierung und Play-Store-Upload bleiben manuelle Schritte (siehe Abschnitt „Android Target API Level" oben, Schritte 1–6), die lokale Android-Tooling/Keystore-Zugriff voraussetzen.
+
 ### Squash-Merge: Feature-Branches nach Merge löschen
 
 Bleiben Feature-Branches nach einem Squash-Merge im Remote stehen, schlägt jeder spätere Merge oder Rebase mit ihnen mit add/add-Konflikten in den ursprünglich gemergten Dateien fehl – Git erkennt die Inhaltsgleichheit der squash-erzeugten Commits nicht, weil sie neue Hashes haben. **Immer Branch nach Merge löschen.** Falls schon zu spät: nur den Diff `branch..main` als Patch ausschneiden, auf einen frischen Branch von main anwenden, alten Branch wegwerfen (siehe Vorgehen bei PR #75).

--- a/scripts/patch-twa-target-sdk36.sh
+++ b/scripts/patch-twa-target-sdk36.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# patch-twa-target-sdk36.sh — Issue #210 (+ #202 resizeableActivity)
+#
+# Der Play-Store-Build ist ein von Bubblewrap generiertes TWA-Projekt. Die
+# generierten Gradle-/Manifest-Dateien (app/build.gradle,
+# app/src/main/AndroidManifest.xml, ...) sind gitignored und werden bei
+# jeder Neugenerierung überschrieben. Solange die installierte Bubblewrap-
+# Version API Level 36 (Android 16) noch nicht selbst als Default setzt,
+# muss compileSdkVersion/targetSdkVersion manuell angehoben werden – siehe
+# CLAUDE.md, Abschnitt "Android Target API Level (Play Store)".
+#
+# Zusätzlich stellt dieses Skript sicher, dass die App als resizierbar
+# markiert ist (android:resizeableActivity="true"), damit die
+# Large-Screen-Warnung aus Issue #202 verschwindet — die Quelle
+# (twa-manifest.template.json → "orientation": "default") ist bereits
+# korrekt, nur das generierte Manifest hinkt hinterher.
+#
+# Dieses Skript nach jeder Bubblewrap-(Re)Generierung ausführen, VOR
+# `./gradlew bundleRelease` (zusätzlich zu patch-twa-edge-to-edge.sh).
+# Idempotent – mehrfaches Ausführen ist unschädlich.
+#
+# Verwendung:  bash scripts/patch-twa-target-sdk36.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+APP_GRADLE="$ROOT/app/build.gradle"
+MANIFEST="$ROOT/app/src/main/AndroidManifest.xml"
+
+# Ziel-API-Level (Play Console verlangt targetSdkVersion 36 ab 31.08.2026)
+TARGET_SDK="36"
+
+if [ ! -f "$APP_GRADLE" ]; then
+  echo "FEHLER: $APP_GRADLE nicht gefunden. Zuerst das TWA-Projekt generieren/bauen." >&2
+  exit 1
+fi
+
+# 1) compileSdkVersion auf TARGET_SDK anheben
+if grep -qE "compileSdkVersion $TARGET_SDK\b" "$APP_GRADLE"; then
+  echo "compileSdkVersion bereits $TARGET_SDK."
+else
+  sed -i '' -E "s/compileSdkVersion [0-9]+/compileSdkVersion $TARGET_SDK/" "$APP_GRADLE"
+  echo "compileSdkVersion → $TARGET_SDK angehoben (app/build.gradle)."
+fi
+
+# 2) targetSdkVersion auf TARGET_SDK anheben
+if grep -qE "targetSdkVersion $TARGET_SDK\b" "$APP_GRADLE"; then
+  echo "targetSdkVersion bereits $TARGET_SDK."
+else
+  sed -i '' -E "s/targetSdkVersion [0-9]+/targetSdkVersion $TARGET_SDK/" "$APP_GRADLE"
+  echo "targetSdkVersion → $TARGET_SDK angehoben (app/build.gradle)."
+fi
+
+# 3) android:resizeableActivity="true" im <application>-Tag sicherstellen
+#    (Issue #202 – Large-Screen-Warnung). twa-manifest.template.json setzt
+#    "orientation": "default" bereits korrekt; das generierte Manifest muss
+#    zusätzlich explizit als resizierbar markiert sein.
+if [ ! -f "$MANIFEST" ]; then
+  echo "WARN: $MANIFEST nicht gefunden – resizeableActivity-Patch übersprungen." >&2
+elif grep -q 'android:resizeableActivity="true"' "$MANIFEST"; then
+  echo "android:resizeableActivity bereits auf true (AndroidManifest.xml)."
+elif grep -q 'android:resizeableActivity="false"' "$MANIFEST"; then
+  sed -i '' -E 's/android:resizeableActivity="false"/android:resizeableActivity="true"/' "$MANIFEST"
+  echo "android:resizeableActivity false → true gesetzt (AndroidManifest.xml)."
+else
+  sed -i '' -E 's/(<application)/\1\n        android:resizeableActivity="true"/' "$MANIFEST"
+  echo "android:resizeableActivity=\"true\" zum <application>-Tag ergänzt (AndroidManifest.xml)."
+fi
+
+echo "Fertig. Target-SDK-36- und Large-Screen-Patch (Issue #210/#202) angewendet."


### PR DESCRIPTION
## Summary

- Fügt `scripts/patch-twa-target-sdk36.sh` hinzu, analog zu `scripts/patch-twa-edge-to-edge.sh` (#206), das nach jeder Bubblewrap-Regenerierung die generierten Android-Artefakte patcht: `compileSdkVersion`/`targetSdkVersion` → 36 (`app/build.gradle`, #210) und `android:resizeableActivity="true"` (`AndroidManifest.xml`, #202)
- Dokumentiert Ablauf und offene manuelle Schritte in `CLAUDE.md`

## Kontext

`android/` ist gitignored und wird lokal via Bubblewrap CLI aus `twa-manifest.template.json` generiert. Beide Issues lassen sich daher **nicht vollständig** per reinem Repo-Commit lösen:

- **#210** (targetSdkVersion 36): `twa-manifest.template.json` enthält kein SDK-Level-Feld – der Bump muss im generierten `app/build.gradle` erfolgen. Das neue Skript automatisiert diesen Schritt.
- **#202** (Large-Screen/resizeableActivity): Die Quelle ist bereits korrekt (`twa-manifest.template.json` → `"orientation": "default"`, verifiziert), nur die generierten Artefakte hinken hinterher. Das Skript ergänzt `android:resizeableActivity="true"` im generierten Manifest.

Die eigentlichen Akzeptanzkriterien beider Issues (Play Console zeigt targetSdkVersion 36 / Large-Screen-Warnung verschwindet) erfordern einen lokalen Build-Zyklus außerhalb dieser Session: Bubblewrap-Regenerierung → `bash scripts/patch-twa-edge-to-edge.sh` → `bash scripts/patch-twa-target-sdk36.sh` → `./gradlew bundleRelease` → Signierung → Play-Store-Upload (Android-SDK-Tooling und Signing-Keystore sind hier nicht verfügbar). Dieser PR bereitet den nächsten lokalen Build vor, damit dieser Schritt nicht mehr manuell in `build.gradle`/`AndroidManifest.xml` gemacht werden muss.

## Test plan

- [x] `bash -n scripts/patch-twa-target-sdk36.sh` (Syntax-Check)
- [ ] Nächster lokaler Bubblewrap-Build: Skript ausführen und verifizieren, dass `compileSdkVersion`/`targetSdkVersion` 36 und `android:resizeableActivity="true"` gesetzt sind
- [ ] AAB bauen, hochladen, Play Console auf verschwundene Warnungen prüfen

---
_Generated by [Claude Code](https://claude.ai/code/session_016WGM1oGEDbyJ6eSXrH64p3)_