### PR TITLE
fix(#213): unübersetzte Default-Aktivitäten/Notizen + Menüleiste auf schmalen Geräten

### DIFF
--- a/__tests__/components/ActivityBar.test.tsx
+++ b/__tests__/components/ActivityBar.test.tsx
@@ -16,6 +16,10 @@ jest.mock('../../src/hooks/useTheme', () => ({
   }),
 }));
 
+jest.mock('../../src/contexts/LanguageContext', () => ({
+  useLanguage: () => ({ t: (key: string) => key, language: 'de' }),
+}));
+
 describe('ActivityBar Component', () => {
   const mockActivity = {
     id: 'test-activity',

--- a/__tests__/screens/AgendaScreen.test.tsx
+++ b/__tests__/screens/AgendaScreen.test.tsx
@@ -112,6 +112,7 @@ describe('AgendaScreen', () => {
             endMonth: 23,
             color: '#4CAF50',
             label: 'Aussaat',
+            isCustomized: true,
           },
         ],
         isDefault: false,

--- a/src/components/ActivityBar.tsx
+++ b/src/components/ActivityBar.tsx
@@ -14,6 +14,8 @@ import { Activity } from '../types';
 import { getContrastTextColor } from '../utils/colorUtils';
 import { MONTH_SHORT } from '../utils/monthHelper';
 import { getActivityTypeByType } from '../constants/activityTypes';
+import { getActivityDisplayLabel } from '../utils/activityLabel';
+import { useLanguage } from '../contexts/LanguageContext';
 import { Icon } from './ui';
 import { radius, shadow, duration as durationTokens } from '../constants/designTokens';
 
@@ -53,6 +55,8 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
   totalMonths = 24,
   cellWidth = 40,
 }) => {
+  const { t } = useLanguage();
+  const displayLabel = getActivityDisplayLabel(activity, t);
   const [isHovered, setIsHovered] = useState(false);
   const [dragPx, setDragPx] = useState(0); // gesnappte visuelle Verschiebung
   const [webDragging, setWebDragging] = useState(false);
@@ -99,7 +103,7 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
     return `${MONTH_SHORT[monthIndex]} ${half}`;
   };
 
-  const tooltipText = `${activity.label}\n${getMonthLabel(activity.startMonth)} - ${getMonthLabel(activity.endMonth)}`;
+  const tooltipText = `${displayLabel}\n${getMonthLabel(activity.startMonth)} - ${getMonthLabel(activity.endMonth)}`;
 
   // ---- Native: PanResponder für Touch-Drag ---------------------------------
   const panResponder = useRef(
@@ -198,7 +202,7 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
     <View style={styles.labelRow}>
       {activityIcon ? <Icon name={activityIcon} size={13} color={contrastColor} /> : null}
       <Text style={[styles.label, { color: contrastColor }]} numberOfLines={1}>
-        {activity.label}
+        {displayLabel}
       </Text>
     </View>
   );
@@ -210,7 +214,7 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
       onMouseLeave: () => setIsHovered(false),
       style: [barStyle, { cursor: webDragging ? 'grabbing' : 'grab' } as unknown as ViewStyle],
       accessibilityRole: 'button',
-      accessibilityLabel: activity.label,
+      accessibilityLabel: displayLabel,
     };
     return (
       <>
@@ -231,7 +235,7 @@ export const ActivityBar: React.FC<ActivityBarProps> = ({
       {...panResponder.panHandlers}
       style={barStyle}
       accessibilityRole="button"
-      accessibilityLabel={activity.label}
+      accessibilityLabel={displayLabel}
     >
       {labelNode}
     </Animated.View>

--- a/src/components/CategoryTabBar.tsx
+++ b/src/components/CategoryTabBar.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef } from 'react';
-import { Animated, View, StyleSheet, TouchableOpacity } from 'react-native';
+import { Animated, View, StyleSheet, TouchableOpacity, ScrollView } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import { useTheme } from '../hooks/useTheme';
 import { useLanguage } from '../contexts/LanguageContext';
@@ -97,35 +97,42 @@ export const CategoryTabBar: React.FC<CategoryTabBarProps> = ({
         { borderBottomColor: theme.border, backgroundColor: theme.surfaceElevated },
       ]}
     >
-      {CATEGORY_TABS.map((tab) => {
-        const isActive = activeCategory === tab.value;
-        const label = language === 'de' ? tab.labelDe : tab.labelEn;
-        return (
-          <CategoryChip
-            key={tab.value}
-            isActive={isActive}
-            color={tab.color}
-            label={label}
-            iconName={tab.iconName}
-            textSecondary={theme.textSecondary}
-            onPress={() => onCategoryChange(tab.value)}
-          />
-        );
-      })}
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.tabBarContent}
+      >
+        {CATEGORY_TABS.map((tab) => {
+          const isActive = activeCategory === tab.value;
+          const label = language === 'de' ? tab.labelDe : tab.labelEn;
+          return (
+            <CategoryChip
+              key={tab.value}
+              isActive={isActive}
+              color={tab.color}
+              label={label}
+              iconName={tab.iconName}
+              textSecondary={theme.textSecondary}
+              onPress={() => onCategoryChange(tab.value)}
+            />
+          );
+        })}
+      </ScrollView>
     </View>
   );
 };
 
 const styles = StyleSheet.create({
   tabBar: {
-    flexDirection: 'row',
     borderBottomWidth: 1,
-    paddingHorizontal: spacing.sm,
     paddingVertical: spacing.sm,
+  },
+  tabBarContent: {
+    flexDirection: 'row',
+    paddingHorizontal: spacing.sm,
     gap: spacing.xs,
   },
   chipTouchable: {
-    flex: 1,
     borderRadius: radius.pill,
     borderWidth: 1,
     overflow: 'hidden',

--- a/src/components/EditActivityModal.tsx
+++ b/src/components/EditActivityModal.tsx
@@ -14,6 +14,7 @@ import { useLanguage } from '../contexts/LanguageContext';
 import { Activity } from '../types';
 import { radius } from '../constants/designTokens';
 import { getActivityTypeByType } from '../constants/activityTypes';
+import { getActivityDisplayLabel } from '../utils/activityLabel';
 import { Icon, SuccessOverlay } from './ui';
 
 interface EditActivityModalProps {
@@ -35,7 +36,7 @@ export const EditActivityModal: React.FC<EditActivityModalProps> = ({
 }) => {
   const { theme } = useTheme();
   const { t } = useLanguage();
-  const [label, setLabel] = useState(activity?.label || '');
+  const [label, setLabel] = useState(activity ? getActivityDisplayLabel(activity, t) : '');
   const [startMonth, setStartMonth] = useState(activity?.startMonth ?? 0);
   const [endMonth, setEndMonth] = useState(activity?.endMonth ?? 0);
   const [rangeError, setRangeError] = useState('');
@@ -44,12 +45,15 @@ export const EditActivityModal: React.FC<EditActivityModalProps> = ({
 
   useEffect(() => {
     if (activity) {
-      setLabel(activity.label);
+      setLabel(getActivityDisplayLabel(activity, t));
       setStartMonth(activity.startMonth);
       setEndMonth(activity.endMonth);
       setRangeError('');
       lastActivityRef.current = activity;
     }
+    // t excluded intentionally: its identity changes on every LanguageProvider
+    // render, which would overwrite in-progress user edits to the label field.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activity]);
 
   // Während der Erfolgs-Animation (nach onDelete) wird `activity` vom Parent auf

--- a/src/components/PlantRow.tsx
+++ b/src/components/PlantRow.tsx
@@ -11,8 +11,10 @@ import {
 import { Plant } from '../types';
 import { ActivityBar } from './ActivityBar';
 import { useTheme } from '../hooks/useTheme';
+import { useLanguage } from '../contexts/LanguageContext';
 import { usePlants } from '../contexts/PlantContext';
 import { calculateActivityRows } from '../utils/activityLayout';
+import { getPlantDisplayNotes } from '../constants/plantNames';
 import { radius } from '../constants/designTokens';
 
 // Vertikaler Abstand pro Aktivitäts-Zeile (muss zur ActivityBar-Höhe passen).
@@ -50,6 +52,7 @@ export const PlantRow: React.FC<PlantRowProps> = ({
   cellWidth = 40,
 }) => {
   const { theme } = useTheme();
+  const { t, language } = useLanguage();
   const { updatePlant } = usePlants();
   const [isEditingNotes, setIsEditingNotes] = useState(false);
   const [notesText, setNotesText] = useState(plant.notes);
@@ -252,7 +255,8 @@ export const PlantRow: React.FC<PlantRowProps> = ({
         ) : (
           <TouchableOpacity onPress={handleNotesPress}>
             <Text style={[styles.notes, { color: theme.textSecondary }]} numberOfLines={2}>
-              {plant.notes || 'Notizen hinzufügen...'}
+              {getPlantDisplayNotes(plant.name, plant.notes, language) ||
+                (t('plants.notesPlaceholder') as string)}
             </Text>
           </TouchableOpacity>
         )}

--- a/src/constants/plantNames.ts
+++ b/src/constants/plantNames.ts
@@ -39,3 +39,87 @@ export function getPlantDisplayName(name: string, language: Language): string {
   if (language === 'de') return name;
   return PLANT_NAME_EN[name] ?? name;
 }
+
+// Default notes as shipped in defaultPlants.ts (German), keyed by plant name.
+// Used to detect whether a plant's notes are still the untouched default text.
+const PLANT_NOTES_DE: Record<string, string> = {
+  Tomaten: 'Beliebtes Gemüse für Garten und Balkon',
+  Erdbeeren: 'Mehrjährige Pflanze',
+  Salat: 'Schnell wachsend',
+  Karotten: 'Wurzelgemüse',
+  Rosen: 'Zierpflanze',
+  Paprika: 'Wärmeliebendes Gemüse',
+  Zucchini: 'Ertragreiche Kürbispflanze',
+  Gurken: 'Kletterpflanze',
+  Radieschen: 'Schnellwachsend',
+  Basilikum: 'Beliebtes Küchenkraut',
+  Kürbis: 'Große Früchte',
+  Kartoffeln: 'Grundnahrungsmittel',
+  Zwiebeln: 'Lagerfähig',
+  Knoblauch: 'Herbstpflanzung',
+  Himbeeren: 'Beerenobst',
+  Lavendel: 'Duftpflanze',
+  Petersilie: 'Zweijähriges Kraut',
+  Schnittlauch: 'Mehrjährig',
+  Spinat: 'Frühjahrs- und Herbstanbau',
+  Apfelbaum: 'Obstbaum',
+  Tulpen: 'Frühjahrszwiebel',
+  Sonnenblumen: 'Einjährige Sommerblume',
+  Dahlien: 'Knollenblume, nicht frosthart',
+  Geranien: 'Balkonpflanze (Pelargonien)',
+  Hortensien: 'Schattenliebender Strauch',
+  Pfingstrosen: 'Mehrjährige Staude',
+  Chrysanthemen: 'Herbstblüher',
+  Ringelblumen: 'Einjährige Heilpflanze',
+  Birnbaum: 'Obstbaum',
+  Kirschbaum: 'Süß- oder Sauerkirsche',
+  Pflaume: 'Steinobst / Zwetschge',
+  Haselnuss: 'Strauch / kleiner Baum',
+};
+
+const PLANT_NOTES_EN: Record<string, string> = {
+  Tomaten: 'Popular vegetable for garden and balcony',
+  Erdbeeren: 'Perennial plant',
+  Salat: 'Fast growing',
+  Karotten: 'Root vegetable',
+  Rosen: 'Ornamental plant',
+  Paprika: 'Heat-loving vegetable',
+  Zucchini: 'High-yielding squash plant',
+  Gurken: 'Climbing plant',
+  Radieschen: 'Fast growing',
+  Basilikum: 'Popular culinary herb',
+  Kürbis: 'Large fruits',
+  Kartoffeln: 'Staple food',
+  Zwiebeln: 'Good keeper',
+  Knoblauch: 'Autumn planting',
+  Himbeeren: 'Berry fruit',
+  Lavendel: 'Fragrant plant',
+  Petersilie: 'Biennial herb',
+  Schnittlauch: 'Perennial',
+  Spinat: 'Spring and autumn cultivation',
+  Apfelbaum: 'Fruit tree',
+  Tulpen: 'Spring bulb',
+  Sonnenblumen: 'Annual summer flower',
+  Dahlien: 'Tuberous flower, not frost-hardy',
+  Geranien: 'Balcony plant (pelargoniums)',
+  Hortensien: 'Shade-loving shrub',
+  Pfingstrosen: 'Perennial',
+  Chrysanthemen: 'Autumn bloomer',
+  Ringelblumen: 'Annual medicinal plant',
+  Birnbaum: 'Fruit tree',
+  Kirschbaum: 'Sweet or sour cherry',
+  Pflaume: 'Stone fruit / plum',
+  Haselnuss: 'Shrub / small tree',
+};
+
+// Translates a plant's notes ONLY if they still match the untouched default
+// German text for that plant name. User-edited notes are left untouched.
+export function getPlantDisplayNotes(
+  name: string,
+  notes: string | undefined,
+  language: Language
+): string | undefined {
+  if (!notes || language === 'de') return notes;
+  if (PLANT_NOTES_DE[name] !== notes) return notes;
+  return PLANT_NOTES_EN[name] ?? notes;
+}

--- a/src/i18n/de.ts
+++ b/src/i18n/de.ts
@@ -87,6 +87,7 @@ const de: Translations = {
   'plants.add': '➕ Neue Pflanze hinzufügen',
   'plants.empty': 'Noch keine Pflanzen vorhanden',
   'plants.activities': 'Aktivitäten',
+  'plants.notesPlaceholder': 'Notizen hinzufügen...',
   'plants.deleteTitle': 'Pflanze löschen',
   'plants.deleteMessage': 'wirklich löschen?',
   'plants.deleteConfirm': 'Löschen',

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -86,6 +86,7 @@ const en: Translations = {
   'plants.add': '➕ Add New Plant',
   'plants.empty': 'No plants yet',
   'plants.activities': 'Activities',
+  'plants.notesPlaceholder': 'Add notes...',
   'plants.deleteTitle': 'Delete Plant',
   'plants.deleteMessage': 'really delete?',
   'plants.deleteConfirm': 'Delete',

--- a/src/i18n/es.ts
+++ b/src/i18n/es.ts
@@ -70,6 +70,7 @@ const es: Translations = {
   'plants.add': '➕ Añadir nueva planta',
   'plants.empty': 'Aún no hay plantas',
   'plants.activities': 'Actividades',
+  'plants.notesPlaceholder': 'Añadir notas...',
   'plants.deleteTitle': 'Eliminar planta',
   'plants.deleteMessage': '¿realmente eliminar?',
   'plants.deleteConfirm': 'Eliminar',

--- a/src/i18n/fr.ts
+++ b/src/i18n/fr.ts
@@ -70,6 +70,7 @@ const fr: Translations = {
   'plants.add': '➕ Ajouter une plante',
   'plants.empty': 'Aucune plante pour le moment',
   'plants.activities': 'Activités',
+  'plants.notesPlaceholder': 'Ajouter des notes...',
   'plants.deleteTitle': 'Supprimer la plante',
   'plants.deleteMessage': 'vraiment supprimer ?',
   'plants.deleteConfirm': 'Supprimer',

--- a/src/i18n/it.ts
+++ b/src/i18n/it.ts
@@ -70,6 +70,7 @@ const it: Translations = {
   'plants.add': '➕ Aggiungi nuova pianta',
   'plants.empty': 'Nessuna pianta ancora',
   'plants.activities': 'Attività',
+  'plants.notesPlaceholder': 'Aggiungi note...',
   'plants.deleteTitle': 'Elimina pianta',
   'plants.deleteMessage': 'eliminare davvero?',
   'plants.deleteConfirm': 'Elimina',

--- a/src/i18n/nl.ts
+++ b/src/i18n/nl.ts
@@ -70,6 +70,7 @@ const nl: Translations = {
   'plants.add': '➕ Nieuwe plant toevoegen',
   'plants.empty': 'Nog geen planten',
   'plants.activities': 'Activiteiten',
+  'plants.notesPlaceholder': 'Notities toevoegen...',
   'plants.deleteTitle': 'Plant verwijderen',
   'plants.deleteMessage': 'echt verwijderen?',
   'plants.deleteConfirm': 'Verwijderen',

--- a/src/i18n/pl.ts
+++ b/src/i18n/pl.ts
@@ -70,6 +70,7 @@ const pl: Translations = {
   'plants.add': '➕ Dodaj nową roślinę',
   'plants.empty': 'Brak roślin',
   'plants.activities': 'Aktywności',
+  'plants.notesPlaceholder': 'Dodaj notatki...',
   'plants.deleteTitle': 'Usuń roślinę',
   'plants.deleteMessage': 'na pewno usunąć?',
   'plants.deleteConfirm': 'Usuń',

--- a/src/i18n/pt.ts
+++ b/src/i18n/pt.ts
@@ -70,6 +70,7 @@ const pt: Translations = {
   'plants.add': '➕ Adicionar nova planta',
   'plants.empty': 'Ainda sem plantas',
   'plants.activities': 'Atividades',
+  'plants.notesPlaceholder': 'Adicionar notas...',
   'plants.deleteTitle': 'Eliminar planta',
   'plants.deleteMessage': 'eliminar mesmo?',
   'plants.deleteConfirm': 'Eliminar',

--- a/src/screens/AgendaScreen.tsx
+++ b/src/screens/AgendaScreen.tsx
@@ -8,6 +8,8 @@ import { CategoryTabBar } from '../components/CategoryTabBar';
 import { getPlantDisplayName } from '../constants/plantNames';
 import { getPlantEmoji } from '../constants/plantEmojis';
 import { getActivityTypeByType } from '../constants/activityTypes';
+import { getActivityDisplayLabel } from '../utils/activityLabel';
+import { getPlantDisplayNotes } from '../constants/plantNames';
 import { Card, Icon, type IconName } from '../components/ui';
 import { radius, spacing } from '../constants/designTokens';
 
@@ -51,17 +53,17 @@ export const AgendaScreen: React.FC = () => {
             activities.push({
               plantName: getPlantDisplayName(plant.name, language),
               plantEmoji: getPlantEmoji(plant.name, plant.category),
-              activityLabel: activity.label,
+              activityLabel: getActivityDisplayLabel(activity, t),
               activityColor: activity.color,
               activityIcon: getActivityTypeByType(activity.type)?.icon,
-              notes: plant.notes,
+              notes: getPlantDisplayNotes(plant.name, plant.notes, language),
             });
           }
         });
       });
       return activities.sort((a, b) => a.plantName.localeCompare(b.plantName, language));
     },
-    [filteredPlants, language]
+    [filteredPlants, language, t]
   );
 
   const monthNames = t('agenda.months') as string[];

--- a/src/screens/PlantManagementScreen.tsx
+++ b/src/screens/PlantManagementScreen.tsx
@@ -16,7 +16,7 @@ import { AddPlantModal } from '../components/AddPlantModal';
 import { EditPlantModal } from '../components/EditPlantModal';
 import { Plant, PlantLocation, PlantCategory } from '../types';
 import { PLANT_LOCATION_METADATA, PLANT_CATEGORY_METADATA } from '../constants/plantMetadata';
-import { getPlantDisplayName } from '../constants/plantNames';
+import { getPlantDisplayName, getPlantDisplayNotes } from '../constants/plantNames';
 import { getPlantEmoji } from '../constants/plantEmojis';
 import { CategoryFilter } from '../constants/categoryTabs';
 import { CategoryTabBar } from '../components/CategoryTabBar';
@@ -163,7 +163,7 @@ export const PlantManagementScreen: React.FC = () => {
                     </View>
                     {plant.notes && (
                       <Text style={[styles.plantNotes, { color: theme.textSecondary }]}>
-                        {plant.notes}
+                        {getPlantDisplayNotes(plant.name, plant.notes, language)}
                       </Text>
                     )}
                     <Text style={[styles.activityCount, { color: theme.textSecondary }]}>

--- a/src/utils/activityLabel.ts
+++ b/src/utils/activityLabel.ts
@@ -1,0 +1,19 @@
+import type { Activity } from '../types';
+import type { TranslationValue } from '../i18n';
+
+/**
+ * Default (non-customized) activities ship with a German label baked in
+ * (see defaultPlants.ts / activityTypes.ts). Re-derive the label from the
+ * activity type via i18n so it matches the current language; a
+ * user-customized label (isCustomized: true) is shown as typed.
+ */
+export function getActivityDisplayLabel(
+  activity: Pick<Activity, 'type' | 'label' | 'isCustomized'>,
+  t: (key: string) => TranslationValue | string
+): string {
+  if (activity.isCustomized) return activity.label;
+  const translated = t(`activity.type.${activity.type}`);
+  return typeof translated === 'string' && translated !== `activity.type.${activity.type}`
+    ? translated
+    : activity.label;
+}


### PR DESCRIPTION
## Beschreibung

Behebt Issue #213 (User Feedback): "Die Menüleiste ist für mein Gerät unübersichtlich, ich kann die Texte nicht lesen. Die englische Sprachunterstützung ist noch nicht vollständig, und der englische Text enthält zu viele deutsche Wörter."

**Ursache der deutschen Wörter im englischen UI:** Die 32 mitgelieferten Standardpflanzen (`defaultPlants.ts`) haben Aktivitäts-Labels (`Aussäen`, `Pflanzen`, `Düngen`, `Ernten`, …) und Notizen fest als deutschen Text einprogrammiert. Pflanzennamen wurden bereits per Wörterbuch übersetzt (`getPlantDisplayName`), Labels/Notizen dagegen nicht – dadurch zeigten englischsprachige Nutzer:innen fast überall deutsche Aktivitätsbezeichnungen im Kalender/in der Agenda.

**Änderungen:**

- Neuer Helper `getActivityDisplayLabel()`: leitet das angezeigte Label für **nicht vom Nutzer angepasste** Aktivitäten (`isCustomized` nicht gesetzt) live aus dem Aktivitätstyp über die vorhandenen `activity.type.*`-i18n-Keys ab. Selbst erstellte/umbenannte Aktivitäten (`isCustomized: true`) bleiben unverändert. Eingesetzt in `ActivityBar`, `AgendaScreen`, `EditActivityModal`.
- Neuer Helper `getPlantDisplayNotes()` (analog zu `getPlantDisplayName`): übersetzt die Notizen einer Standardpflanze per Wörterbuch, aber nur solange sie noch exakt dem unveränderten deutschen Default-Text entsprechen – eigene Notizen des Nutzers bleiben unangetastet. Eingesetzt in `PlantRow`, `PlantManagementScreen`, `AgendaScreen`.
- `PlantRow`: Platzhaltertext "Notizen hinzufügen..." war fest deutsch verdrahtet (kein i18n) und erschien auch im englischen UI. Neuer i18n-Key `plants.notesPlaceholder` in allen 8 Sprachen ergänzt.
- `CategoryTabBar` (Kategorie-Filterleiste auf Agenda/Pflanzen/Vorlagen): Die Chips teilten sich den Platz per `flex: 1`, wodurch längere Labels (z. B. "Nutzpflanzen") auf schmalen Geräten gequetscht/unleserlich wurden. Die Leiste ist jetzt horizontal scrollbar, Chips behalten ihre natürliche Breite – Text bleibt vollständig lesbar statt abgeschnitten/verkleinert.

## Art der Änderung

- [x] Bugfix (non-breaking change)

## Cross-Platform Kompatibilität

**Betrifft dieser PR plattformspezifischen Code?** Nein (reine RN-Komponenten/i18n-Daten, keine `window.*`/`document`-Nutzung).

## Testing Checklist

- [x] Lokaler Build erfolgreich (`expo export --platform web`)
- [x] Keine TypeScript Errors (`tsc --noEmit`)
- [x] Keine ESLint Warnings, `prettier --check` clean
- [x] Alle 384 Tests grün (`npx jest`) – zwei Tests angepasst: `ActivityBar.test.tsx` mockt jetzt `LanguageContext` (Komponente nutzt neu `useLanguage`), `AgendaScreen.test.tsx`-Fixture setzt `isCustomized: true` für ihr Test-Label, das absichtlich vom Default-Label abweicht

## Zusätzliche Notizen

Kein Screenshot vom betroffenen Gerät verfügbar; der Menüleisten-Fix adressiert den konkret identifizierbaren Ursache-Kandidaten (textquetschende `flex:1`-Chips). Die Haupt-Tab-Bar (`app/_layout.tsx`) wurde nicht angefasst, da dort keine vergleichbare Quetschung vorliegt.


---
_Generated by [Claude Code](https://claude.ai/code/session_01XMwhyrckhW32kUydccaQnm)_